### PR TITLE
[FEAT] 산책 모임 만들기 페이지

### DIFF
--- a/client/components/walks/wirte/DateSelectBox.tsx
+++ b/client/components/walks/wirte/DateSelectBox.tsx
@@ -1,0 +1,10 @@
+import TimeSelectBox from './TimeSelectBox';
+
+export default function DateSelectBox() {
+  return (
+    <>
+      <div>DateSelectBox</div>
+      <TimeSelectBox />
+    </>
+  );
+}

--- a/client/components/walks/wirte/DaySelectBox.tsx
+++ b/client/components/walks/wirte/DaySelectBox.tsx
@@ -1,0 +1,10 @@
+import TimeSelectBox from './TimeSelectBox';
+
+export default function DaySelectBox() {
+  return (
+    <>
+      <div>DaySelectBox</div>
+      <TimeSelectBox />
+    </>
+  );
+}

--- a/client/components/walks/wirte/PersonCountInput.tsx
+++ b/client/components/walks/wirte/PersonCountInput.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { Control, Controller } from 'react-hook-form';
+import { WalksMoim } from '../../../models/WalksMoim';
+
+export default function PersonCountInput({
+  control,
+}: {
+  control: Control<WalksMoim>;
+}) {
+  const [isEdit, setIsEdit] = useState(false);
+
+  const handleEditButtonClick = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+    setIsEdit(true);
+  };
+
+  return (
+    <Controller
+      rules={{
+        validate: {
+          min: (v) => v >= 2 || '최소 2명 이상이어야 합니다.',
+        },
+      }}
+      control={control}
+      name="personCount"
+      render={({ field: { onChange, value }, fieldState: { error } }) => {
+        const onChangeWithMin = (value: number) => {
+          if ((value !== 0 && value < 2) || isNaN(value)) {
+            return;
+          }
+
+          onChange(value);
+        };
+        return (
+          <>
+            <button type="button" onClick={() => onChangeWithMin(value - 1)}>
+              -
+            </button>
+            {isEdit ? (
+              <input
+                autoFocus
+                type="text"
+                value={value}
+                onBlur={() => setIsEdit(false)}
+                onChange={(e) => onChangeWithMin(Number(e.target.value))}
+              />
+            ) : (
+              <span onClick={handleEditButtonClick}>{value}</span>
+            )}
+            <button type="button" onClick={() => onChange(value + 1)}>
+              +
+            </button>
+            {error && <p>{error.message}</p>}
+          </>
+        );
+      }}
+    />
+  );
+}

--- a/client/components/walks/wirte/TimeSelectBox.tsx
+++ b/client/components/walks/wirte/TimeSelectBox.tsx
@@ -1,0 +1,3 @@
+export default function TimeSelectBox() {
+  return <input type="time" />;
+}

--- a/client/models/WalksMoim.ts
+++ b/client/models/WalksMoim.ts
@@ -1,0 +1,6 @@
+export interface WalksMoim {
+  name: string;
+  place: string;
+  description: string;
+  personCount: number;
+}

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "next": "12.3.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.35.0",
     "react-query": "^3.39.2",
     "recoil": "^0.7.5"
   },

--- a/client/pages/walks/write.tsx
+++ b/client/pages/walks/write.tsx
@@ -1,10 +1,175 @@
+import { css } from '@emotion/react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 import TabTitle from '../../components/TabTitle';
+import DateSelectBox from '../../components/walks/wirte/DateSelectBox';
+import DaySelectBox from '../../components/walks/wirte/DaySelectBox';
+import PersonCountInput from '../../components/walks/wirte/PersonCountInput';
+import { WalksMoim } from '../../models/WalksMoim';
+import { Theme } from '../../styles/Theme';
 
 export default function Write() {
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm<WalksMoim>({
+    mode: 'onChange',
+    defaultValues: {
+      personCount: 2,
+    },
+  });
+
+  const [plan, setPlan] = useState('day');
+
+  const handlePlanSelectButtonClick = (buttonType: string) => {
+    setPlan(buttonType);
+  };
+
   return (
-    <section>
+    <>
       <TabTitle prefix="모임 글쓰기" />
-      <h1>산책을 등록할 수 있는 페이지 입니다!</h1>
-    </section>
+      <section css={moimFormContainer}>
+        <h1>🐕 산책 모임 만들기</h1>
+        <form>
+          <ul>
+            <li>
+              <label htmlFor="moim-name">모임의 이름을 지어주세요.</label>
+              <input
+                type="text"
+                id="moim-name"
+                {...register('name', {
+                  validate: {
+                    empty: (v) =>
+                      (v != null && v !== '') || '모임의 이름을 입력해주세요.',
+                  },
+                })}
+              />
+              {errors.name ? <p>{errors.name.message}</p> : <p></p>}
+            </li>
+            <li>
+              <label htmlFor="moim-place">자세한 모임 장소를 알려주세요.</label>
+              <input
+                type="text"
+                id="moim-place"
+                {...register('place', {
+                  validate: {
+                    empty: (v) =>
+                      (v != null && v !== '') || '모임의 장소를 입력해주세요.',
+                  },
+                })}
+              />
+              {errors.place ? <p>{errors.place.message}</p> : <p></p>}
+            </li>
+            <li>
+              <label htmlFor="moim-description">어떤 산책을 하고 싶나요?</label>
+              <textarea
+                id="moim-description"
+                placeholder="저희 강쥐가 낯을 많이 가려서 비슷하게 순둥하게 산책할 친구 찾아요!"
+                {...register('description', {
+                  validate: {
+                    empty: (v) =>
+                      (v != null && v !== '') || '내용을 입력해주세요.',
+                  },
+                })}
+              />
+              {errors.description ? (
+                <p>{errors.description.message}</p>
+              ) : (
+                <p></p>
+              )}
+            </li>
+            <li>
+              <label htmlFor="moim-personCount">정원을 정해주세요</label>
+              <PersonCountInput control={control} />
+            </li>
+            <li>
+              <label htmlFor="moim-plan">모임 날짜를 정해주세요.</label>
+            </li>
+            <li>
+              <button
+                type="button"
+                className={plan === 'day' ? 'active' : ''}
+                onClick={() => handlePlanSelectButtonClick('day')}
+              >
+                요일로 선택하기
+              </button>
+              <button
+                type="button"
+                className={plan === 'date' ? 'active' : ''}
+                onClick={() => handlePlanSelectButtonClick('date')}
+              >
+                날짜로 선택하기
+              </button>
+            </li>
+            <li>{plan === 'day' ? <DaySelectBox /> : <DateSelectBox />}</li>
+            <li>
+              <button
+                type="button"
+                onClick={handleSubmit((e) => {
+                  console.log(e);
+                })}
+              >
+                등록
+              </button>
+            </li>
+          </ul>
+        </form>
+      </section>
+    </>
   );
 }
+
+const moimFormContainer = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 800px;
+  border: 1px solid;
+  margin: 0 auto;
+
+  form ul li {
+    margin-top: 20px;
+  }
+
+  form {
+    padding: 0 36px;
+    width: 100%;
+  }
+
+  ul {
+    list-style: none;
+  }
+
+  li {
+    label {
+      display: block;
+      margin-bottom: 20px;
+      font-weight: 600;
+    }
+
+    input {
+      width: 100%;
+      padding: 10px;
+      background-color: #f7f7f5;
+      border: 1px solid #f7f7f5;
+      border-radius: 15px;
+    }
+
+    textarea {
+      width: 100%;
+      height: 200px;
+      padding: 10px;
+      background-color: ${Theme.inputBgColor};
+      border: 1px solid ${Theme.inputBgColor};
+      border-radius: 15px;
+    }
+
+    p {
+      height: 17px;
+      color: ${Theme.errorMessagesColor};
+      font-size: 12px;
+    }
+  }
+`;

--- a/client/styles/Theme.ts
+++ b/client/styles/Theme.ts
@@ -1,0 +1,4 @@
+export const Theme = {
+  inputBgColor: '#f7f7f5',
+  errorMessagesColor: '#b90000',
+};


### PR DESCRIPTION
- 일단은 모임 정원을 정하는 부분만 따로 컴포넌트로 분리한 상태입니다! 차차 분리해나가겠습니다!
- 인풋에 내용이 없을 때 내용을 입력하라는 메시지가 뜨게 했습니다. 
- 정원은 2명 미만으로 선택되지 않도록 했고, 만약 하더라도 2명 이상이어야 된다는 메시지가 뜨게 했습니다. + 클릭하면 정원을 수정할 수 있게 해봤는데 너무 거추장스러우면 기능 삭제하도록 하겠습니다.
- 현재 등록 버튼을 누르면 콘솔창에 입력한 내용을 확인할 수 있습니다.

-  `client/styles/Theme.ts` 이 파일은 아직 고민인데, 이런 식으로 자주 사용하는 색깔을 변수로 만들어서 사용하면 어떨까 싶어서 시도해봤습니다.
- `client/models` 이 폴더 안에 type 관련 코드 넣어봤습니다!
- 요일/날짜로 선택하기 기능은 아직 구현하지 못했습니다! 곧 해내겟습니당

<img width="1069" alt="스크린샷 2022-09-15 오후 6 21 22" src="https://user-images.githubusercontent.com/76990149/190368755-93579f8e-0b26-46a2-8d0d-580801c58149.png">
<img width="650" alt="스크린샷 2022-09-15 오후 6 21 40" src="https://user-images.githubusercontent.com/76990149/190368770-f3640644-deca-4350-933a-9225eee3807f.png">

