### PR TITLE
[FEAT] write 페이지의 달력/시간 모달 구현

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -1,10 +1,23 @@
+import { css } from '@emotion/react';
 import Navbar from './Navbar';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Navbar />
-      <main>{children}</main>
+      <main
+        css={css`
+          max-width: 1200px;
+          margin: 75px auto 0;
+          min-height: calc(100vh - 75px);
+
+          @media screen and (max-width: 768px) {
+            margin: 0px 0 72px;
+          }
+        `}
+      >
+        {children}
+      </main>
     </>
   );
 }

--- a/client/components/Navbar.tsx
+++ b/client/components/Navbar.tsx
@@ -14,6 +14,7 @@ export default function Navbar() {
       justify-content: space-around;
       align-items: center;
       height: 72px;
+      z-index: 1;
       a {
         opacity: 50%;
         color: #dc602a;
@@ -48,6 +49,10 @@ export default function Navbar() {
     height: 75px;
     width: 100%;
     background-color: #fff3e3;
+    position: fixed;
+    top: 0;
+    width: 100%;
+
     a {
       text-decoration: none;
       color: black;

--- a/client/components/walks/wirte/EveryWeekPicker.tsx
+++ b/client/components/walks/wirte/EveryWeekPicker.tsx
@@ -20,7 +20,9 @@ export default function DaySelectBox() {
     <>
       <Controller
         rules={{
-          validate: {},
+          validate: {
+            required: (value) => value?.length > 0 || '요일을 선택해주세요.',
+          },
         }}
         control={control}
         name="plannedDates"
@@ -30,35 +32,61 @@ export default function DaySelectBox() {
         }) => {
           return (
             <>
-              {(Object.keys(YOIL) as Array<keyof typeof YOIL>).map((day) => {
-                const 요일 = day;
-                const yoil = YOIL[요일];
-
-                return (
-                  <button
-                    css={css`
-                      ${yoilArr.includes(yoil)
-                        ? `background-color: ${Theme.mainColor}; color: white;`
-                        : ''}
-                    `}
-                    type="button"
-                    key={`${yoil}-button`}
-                    onClick={() => {
-                      if (yoilArr.includes(yoil)) {
-                        onChange(yoilArr.filter((x) => x !== yoil));
-                      } else {
-                        onChange([...yoilArr, yoil]);
+              <div
+                css={css`
+                  display: flex;
+                  align-items: center;
+                  gap: 10px;
+                `}
+              >
+                <p
+                  css={css`
+                    font-size: 1rem;
+                    font-weight: 500;
+                  `}
+                >
+                  매주
+                </p>
+                {(Object.keys(YOIL) as Array<keyof typeof YOIL>).map((day) => {
+                  const 요일 = day;
+                  const yoil = YOIL[요일];
+                  return (
+                    <button
+                      css={css`
+                        cursor: pointer;
+                        border: none;
+                        padding: 10px 12px;
+                        border-radius: 50px;
+                        background: ${yoilArr.includes(yoil)
+                          ? Theme.mainColor
+                          : '#F7F7F5'};
+                        color: ${yoilArr.includes(yoil) ? '#fff' : '#000'};
+                      `}
+                      className={
+                        yoilArr.includes(yoil)
+                          ? 'yoil-button active'
+                          : 'yoil-button'
                       }
-                    }}
-                  >
-                    {요일}
-                  </button>
-                );
-              })}
-              <TimeSelectBox />
+                      type="button"
+                      key={`${yoil}-button`}
+                      onClick={() => {
+                        if (yoilArr.includes(yoil)) {
+                          onChange(yoilArr.filter((x) => x !== yoil));
+                        } else {
+                          onChange([...yoilArr, yoil]);
+                        }
+                      }}
+                    >
+                      {요일}
+                    </button>
+                  );
+                })}
+              </div>
+
               <div css={errormessageContainer}>
                 {error && <p>{error.message}</p>}
               </div>
+              <TimeSelectBox />
             </>
           );
         }}

--- a/client/components/walks/wirte/OneDayPicker.tsx
+++ b/client/components/walks/wirte/OneDayPicker.tsx
@@ -18,7 +18,7 @@ const errormessageContainer = css`
 `;
 
 export default function DateSelectBox() {
-  const { control } = useFormContext<WalksMoimOneDay>(); // retrieve all hook methods
+  const { control } = useFormContext<WalksMoimOneDay>();
 
   return (
     <>
@@ -34,16 +34,31 @@ export default function DateSelectBox() {
           return (
             <>
               <DatePicker
+                autoFocus
                 locale="ko"
                 selected={value}
-                onChange={(date: Date) => onChange(date)}
                 minDate={new Date()}
-                dateFormat="yyyy.MM.dd"
-              />
-              <TimeSelectBox />
+                onChange={(date: Date) => onChange(date)}
+                dateFormat="yyyy년 MM월 dd일 E요일"
+                isClearable
+                withPortal
+                placeholderText="여기를 눌러 날짜를 선택해주세요."
+                // closeOnScroll={true}
+              >
+                <div
+                  css={css`
+                    color: ${Theme.errorMessagesColor};
+                    text-align: center;
+                    margin: 20px 0;
+                  `}
+                >
+                  날씨를 확인하는 것을 잊지 마세요!
+                </div>
+              </DatePicker>
               <div css={errormessageContainer}>
                 {error && <p>{error.message}</p>}
               </div>
+              <TimeSelectBox />
             </>
           );
         }}

--- a/client/components/walks/wirte/PlaceInput.tsx
+++ b/client/components/walks/wirte/PlaceInput.tsx
@@ -3,7 +3,7 @@ import { FieldErrorsImpl, UseFormRegister } from 'react-hook-form';
 import { WalksMoim } from '../../../models/WalksMoim';
 import { Theme } from '../../../styles/Theme';
 
-const PlaceInputContainer = css`
+const placeInputContainer = css`
   width: 100%;
   padding: 20px 10px;
   background-color: #f7f7f5;
@@ -32,7 +32,7 @@ export default function PlaceInput({
       <input
         type="text"
         id="moim-place"
-        css={PlaceInputContainer}
+        css={placeInputContainer}
         {...register('place', {
           validate: {
             empty: (v) =>

--- a/client/components/walks/wirte/TimeSelectBox.tsx
+++ b/client/components/walks/wirte/TimeSelectBox.tsx
@@ -14,14 +14,14 @@ const errormessageContainer = css`
 `;
 
 export default function TimeSelectBox() {
-  const { control } = useFormContext<WalksMoimOneDay>(); // retrieve all hook methods
+  const { control } = useFormContext<WalksMoimOneDay>();
 
   return (
     <>
       <Controller
         rules={{
           validate: {
-            required: (value) => value != null || '날짜를 선택해주세요.',
+            required: (value) => value != null || '시간을 선택해주세요.',
           },
         }}
         control={control}
@@ -33,12 +33,17 @@ export default function TimeSelectBox() {
                 locale="ko"
                 selected={value}
                 onChange={(time: Date) => onChange(time)}
-                timeIntervals={10}
                 showTimeSelect
                 showTimeSelectOnly
-                timeCaption="시간"
+                timeIntervals={10}
+                timeCaption="시간을 선택해주세요"
                 dateFormat="aa HH:mm"
-              />
+                withPortal
+                isClearable
+                placeholderText="여기를 눌러 시간을 선택해주세요."
+                className="time-picker"
+                // closeOnScroll={true}
+              ></DatePicker>
               <div css={errormessageContainer}>
                 {error && <p>{error.message}</p>}
               </div>

--- a/client/components/walks/wirte/TitleInput.tsx
+++ b/client/components/walks/wirte/TitleInput.tsx
@@ -8,7 +8,7 @@ import {
 import { WalksMoim } from '../../../models/WalksMoim';
 import { Theme } from '../../../styles/Theme';
 
-const nameInputContainer = css`
+const titleInputContainer = css`
   width: 100%;
   padding: 20px 10px;
   background-color: ${Theme.inputBgColor};
@@ -25,7 +25,7 @@ const errormessageContainer = css`
   }
 `;
 
-export default function NameInput({
+export default function TitleInput({
   register,
   errors,
   setFocus,
@@ -35,16 +35,16 @@ export default function NameInput({
   setFocus: UseFormSetFocus<WalksMoim>;
 }) {
   useEffect(() => {
-    setFocus('name');
+    setFocus('title');
   }, [setFocus]);
 
   return (
     <>
       <input
         type="text"
-        id="moim-name"
-        css={nameInputContainer}
-        {...register('name', {
+        id="moim-title"
+        css={titleInputContainer}
+        {...register('title', {
           validate: {
             empty: (v) =>
               (v != null && v !== '') || '모임의 이름을 입력해주세요.',
@@ -52,7 +52,7 @@ export default function NameInput({
         })}
       />
       <div css={errormessageContainer}>
-        {errors.name && <p>{errors.name.message}</p>}
+        {errors.title && <p>{errors.title.message}</p>}
       </div>
     </>
   );

--- a/client/models/WalksMoim.ts
+++ b/client/models/WalksMoim.ts
@@ -11,7 +11,7 @@ export enum YOIL {
 export type Yoil = `${YOIL}`;
 
 interface WalksMoimBase {
-  name: string;
+  title: string;
   place: string;
   description: string;
   personCount: number;

--- a/client/pages/walks/write.tsx
+++ b/client/pages/walks/write.tsx
@@ -1,15 +1,17 @@
 import { css } from '@emotion/react';
 import { useEffect, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
+import CommonButton from '../../components/CommonButton';
 import TabTitle from '../../components/TabTitle';
 import DescriptionInput from '../../components/walks/wirte/DescriptionInput';
 import EveryWeekPicker from '../../components/walks/wirte/EveryWeekPicker';
-import NameInput from '../../components/walks/wirte/NameInput';
 import OneDayPicker from '../../components/walks/wirte/OneDayPicker';
 import PersonCountInput from '../../components/walks/wirte/PersonCountInput';
 import PlaceInput from '../../components/walks/wirte/PlaceInput';
+import TitleInput from '../../components/walks/wirte/TitleInput';
 import { WalksMoim } from '../../models/WalksMoim';
 import 'react-datepicker/dist/react-datepicker.css';
+import { Theme } from '../../styles/Theme';
 
 export default function Write() {
   const methods = useForm<WalksMoim>({
@@ -24,7 +26,7 @@ export default function Write() {
     handleSubmit,
     control,
     setFocus,
-    formState: { errors },
+    formState: { errors, isValid },
     resetField,
   } = methods;
 
@@ -32,6 +34,10 @@ export default function Write() {
 
   const handlePlanSelectButtonClick = (buttonType: string) => {
     setPlan(buttonType);
+  };
+
+  const onSubmit = (data: WalksMoim) => {
+    console.log(data);
   };
 
   useEffect(() => {
@@ -51,7 +57,7 @@ export default function Write() {
             <ul>
               <li>
                 <label htmlFor="moim-name">모임의 이름을 지어주세요.</label>
-                <NameInput
+                <TitleInput
                   register={register}
                   errors={errors}
                   setFocus={setFocus}
@@ -77,14 +83,22 @@ export default function Write() {
                 <label htmlFor="moim-plan">모임 날짜를 정해주세요.</label>
                 <button
                   type="button"
-                  className={plan === 'day' ? 'active' : ''}
+                  className={
+                    plan === 'day'
+                      ? 'date-select-button active'
+                      : 'date-select-button'
+                  }
                   onClick={() => handlePlanSelectButtonClick('day')}
                 >
                   요일로 선택하기
                 </button>
                 <button
                   type="button"
-                  className={plan === 'date' ? 'active' : ''}
+                  className={
+                    plan === 'date'
+                      ? 'date-select-button active'
+                      : 'date-select-button'
+                  }
                   onClick={() => handlePlanSelectButtonClick('date')}
                 >
                   날짜로 선택하기
@@ -92,14 +106,13 @@ export default function Write() {
               </li>
               <li>{plan === 'day' ? <EveryWeekPicker /> : <OneDayPicker />}</li>
               <li>
-                <button
+                <CommonButton
                   type="button"
-                  onClick={handleSubmit((e) => {
-                    console.log(e);
-                  })}
+                  onClick={handleSubmit(onSubmit)}
+                  disabled={!isValid}
                 >
                   등록
-                </button>
+                </CommonButton>
               </li>
             </ul>
           </form>
@@ -111,12 +124,12 @@ export default function Write() {
 
 const moimFormContainer = css`
   max-width: 800px;
-  border: 1px solid;
   margin: 0 auto;
+  padding: 35px;
 
   h1 {
-    margin: 38px;
     text-align: start;
+    color: ${Theme.mainColor};
   }
 
   form ul li {
@@ -124,7 +137,6 @@ const moimFormContainer = css`
   }
 
   form {
-    padding: 0 36px;
     width: 100%;
   }
 
@@ -139,5 +151,25 @@ const moimFormContainer = css`
       font-weight: 600;
       font-size: 1.1rem;
     }
+  }
+
+  button.date-select-button {
+    border: none;
+    padding: 13px 16px;
+    border-radius: 20px;
+    background-color: ${Theme.disableBgColor};
+    color: ${Theme.disableColor};
+    font-size: 0.75rem;
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  button.date-select-button.active {
+    background-color: ${Theme.mainColor};
+    color: #fff;
+  }
+
+  button.date-select-button + button.date-select-button {
+    margin-left: 10px;
   }
 `;

--- a/client/styles/GlobalStyle.tsx
+++ b/client/styles/GlobalStyle.tsx
@@ -1,4 +1,5 @@
 import { Global, css } from '@emotion/react';
+import { Theme } from './Theme';
 
 const globalStyles = css`
   * {
@@ -9,6 +10,159 @@ const globalStyles = css`
       Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo',
       'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji',
       'Segoe UI Symbol', sans-serif;
+  }
+
+  // 시간 선택
+
+  .react-datepicker-time__header {
+    color: ${Theme.mainColor};
+    font-size: 1rem !important;
+    font-weight: 600;
+  }
+
+  .react-datepicker__header {
+    background-color: #fff;
+    border-bottom: none;
+  }
+
+  .react-datepicker--time-only {
+    width: 300px !important;
+
+    @media screen and (max-width: 310px) {
+      width: 250px !important;
+    }
+  }
+
+  .react-datepicker__time-container,
+  .react-datepicker__time-box {
+    width: 100% !important;
+  }
+
+  .react-datepicker__time-list {
+    li {
+      margin-top: 0 !important;
+    }
+  }
+
+  .react-datepicker__time-container
+    .react-datepicker__time
+    .react-datepicker__time-box
+    ul.react-datepicker__time-list
+    li.react-datepicker__time-list-item {
+    height: unset !important;
+    padding: 15px 0px;
+  }
+
+  .react-datepicker__month-container {
+    float: unset;
+  }
+
+  .react-datepicker__time-list .react-datepicker__time-list-item--selected {
+    border-radius: 20px !important;
+  }
+
+  // 달력
+
+  .react-datepicker {
+    border-radius: 20px;
+    padding: 0 10px;
+    overflow: hidden;
+  }
+
+  .react-datepicker__current-month {
+    margin-top: 20px;
+    padding-left: 15px;
+    text-align: start;
+    font-size: 1rem !important;
+    font-weight: 600;
+  }
+
+  .react-datepicker__navigation--previous {
+    left: unset;
+    right: 52px !important;
+  }
+
+  .react-datepicker__navigation--next {
+    right: 20px !important;
+  }
+
+  .react-datepicker__navigation {
+    top: 22.6px !important;
+  }
+
+  .react-datepicker__navigation-icon--next,
+  .react-datepicker__navigation-icon--previous {
+    &::before {
+      border-color: ${Theme.mainColor} !important;
+    }
+  }
+
+  .react-datepicker__navigation:hover *::before {
+    border-color: #f49870 !important;
+  }
+
+  .react-datepicker__day-names {
+    font-size: 0.8rem !important;
+    font-weight: 500 !important;
+    margin-top: 12px !important;
+  }
+
+  .react-datepicker__day-names {
+    .react-datepicker__day-name {
+      color: ${Theme.disableColor} !important;
+    }
+  }
+
+  .react-datepicker__month {
+    font-weight: 400 !important;
+
+    height: 350px;
+
+    @media screen and (max-width: 400px) {
+      height: 300px;
+    }
+  }
+
+  .react-datepicker__day--today,
+  .react-datepicker__day--keyboard-selected {
+    font-weight: unset !important;
+  }
+
+  .react-datepicker__day--selected {
+    background-color: ${Theme.mainColor} !important;
+  }
+
+  .react-datepicker__day:hover {
+    background-color: #f4987085 !important;
+    color: #fff !important;
+    border-radius: 50% !important;
+  }
+
+  .react-datepicker__close-icon::after {
+    background-color: ${Theme.mainColor} !important;
+    height: 25px !important;
+    width: 25px !important;
+    font-size: 1.2rem !important;
+    line-height: 1.2 !important;
+  }
+
+  .react-datepicker__input-container > input {
+    width: calc(100% - 38px) !important;
+    padding: 20px 30px;
+    background-color: #f7f7f5;
+    border: 1px solid #f7f7f5;
+    border-radius: 15px;
+  }
+
+  [aria-selected='true'] {
+    background-color: ${Theme.mainColor} !important;
+    color: #fff !important;
+    border-radius: 50% !important;
+  }
+
+  .react-datepicker__day--keyboard-selected {
+    background-color: unset !important;
+    color: ${Theme.mainColor} !important;
   }
 `;
 


### PR DESCRIPTION
- 달력과 시간 고르는 컴포넌트의 css 를 수정했습니다.
- 모바일 버전 Navbar에 z-index를 설정했습니다.
- 데스크탑 버전 Navbar에 fixed 적용했습니다.
- 변수 이름 변경 후 오타 수정했습니다.

<img width="513" alt="스크린샷 2022-09-19 오전 10 11 28" src="https://user-images.githubusercontent.com/76990149/190936383-a63054fa-4c64-41ce-b21d-9f147fd2afb9.png">
<img width="434" alt="스크린샷 2022-09-19 오전 10 11 39" src="https://user-images.githubusercontent.com/76990149/190936388-f3149bcc-85ce-4723-b0b5-98cb46d864c3.png">
<img width="517" alt="스크린샷 2022-09-19 오전 10 11 47" src="https://user-images.githubusercontent.com/76990149/190936394-f1bcbbdb-fa8b-4b33-a901-7ea61cf0dcfe.png">
<img width="511" alt="스크린샷 2022-09-19 오전 10 11 57" src="https://user-images.githubusercontent.com/76990149/190936398-1eb57196-76f3-4b5d-92cd-8b8a19947032.png">
