### PR TITLE
[FEAT] 산책 디테일 페이지

### DIFF
--- a/client/apis/api.ts
+++ b/client/apis/api.ts
@@ -3,4 +3,5 @@ const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 export const API = {
   WALKS: `${BASE_URL}/communities`,
   PICKPET: `${BASE_URL}/members/pets`,
+  COMMUNITYDETAIL: `${BASE_URL}/community`,
 };

--- a/client/components/walks/walksDetail/Comments.tsx
+++ b/client/components/walks/walksDetail/Comments.tsx
@@ -1,0 +1,40 @@
+/* eslint-disable @next/next/no-img-element */
+import { css } from '@emotion/react';
+import { WalkDetail } from '../../../models/WalkDefault';
+
+export default function Comments({ walksData }: { walksData: WalkDetail }) {
+  return (
+    <article>
+      <h2>댓글 {walksData?.comments?.length}</h2>
+      <ul>
+        {walksData.comments == null ? (
+          <span>로딩</span>
+        ) : (
+          walksData.comments.map((item) => (
+            <li key={item['user.name']}>
+              <div>
+                <img
+                  src="/main_image.jpg"
+                  css={css`
+                    width: 35px;
+                    height: 35px;
+                    object-fit: cover;
+                  `}
+                  alt={item['user.name']}
+                />
+                <div>
+                  <p>{item['user.name']}</p>
+                  <p>{item.comment}</p>
+                  <div>
+                    <button>수정</button>
+                    <button>삭제</button>
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))
+        )}
+      </ul>
+    </article>
+  );
+}

--- a/client/components/walks/walksDetail/DetailLayout.tsx
+++ b/client/components/walks/walksDetail/DetailLayout.tsx
@@ -1,0 +1,35 @@
+import { useRouter } from 'next/router';
+import React from 'react';
+import { useWalksDetailQuery } from '../../../hooks/WalksDetailQuery';
+import { WalkDetail } from '../../../models/WalkDefault';
+import Comments from './Comments';
+import Information from './Information';
+import PageNav from './PageNav';
+import ParticipantsInfo from './ParticipantsInfo';
+import Title from './Title';
+
+export default function DetailLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const walkId = router.query.walkId as string;
+  const walksData: WalkDetail = useWalksDetailQuery(walkId);
+  return (
+    <section>
+      {walksData == null ? (
+        <div>로딩중</div>
+      ) : (
+        <>
+          <Title walksData={walksData} />
+          <Information walksData={walksData} />
+          <PageNav />
+          {children}
+          <ParticipantsInfo walksData={walksData} />
+          <Comments walksData={walksData} />
+        </>
+      )}
+    </section>
+  );
+}

--- a/client/components/walks/walksDetail/Information.tsx
+++ b/client/components/walks/walksDetail/Information.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { WalkDetail } from '../../../models/WalkDefault';
+
+export default function Information({ walksData }: { walksData: WalkDetail }) {
+  return (
+    <ul>
+      <li>일시</li>
+      <li>{walksData?.time?.split(' ')[0]}</li>
+      <li>시간대</li>
+      <li>{walksData?.time?.split(' ')[1]} ~</li>
+      <li>장소</li>
+      <li>{walksData.address}</li>
+    </ul>
+  );
+}

--- a/client/components/walks/walksDetail/Introduce.tsx
+++ b/client/components/walks/walksDetail/Introduce.tsx
@@ -1,0 +1,12 @@
+/* eslint-disable @next/next/no-img-element */
+import { WalkDetail } from '../../../models/WalkDefault';
+
+export default function Introduce({ walksData }: { walksData: WalkDetail }) {
+  return (
+    <>
+      <article>
+        <p>{walksData.body}</p>
+      </article>
+    </>
+  );
+}

--- a/client/components/walks/walksDetail/MoimNotice.tsx
+++ b/client/components/walks/walksDetail/MoimNotice.tsx
@@ -1,0 +1,3 @@
+export default function MoimNotice() {
+  return <div>Notice</div>;
+}

--- a/client/components/walks/walksDetail/PageNav.tsx
+++ b/client/components/walks/walksDetail/PageNav.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+export default function PageNav() {
+  const router = useRouter();
+  const walkId = router.query.walkId as string;
+  return (
+    <ul>
+      <li>
+        <Link href={`/walks/${walkId}`}>
+          <a>모임 소개</a>
+        </Link>
+      </li>
+      <li>
+        <Link href={`/walks/${walkId}/notice`}>
+          <a>모임 공지사항</a>
+        </Link>
+      </li>
+    </ul>
+  );
+}

--- a/client/components/walks/walksDetail/ParticipantsInfo.tsx
+++ b/client/components/walks/walksDetail/ParticipantsInfo.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable @next/next/no-img-element */
+import { css } from '@emotion/react';
+import React from 'react';
+import { WalkDetail } from '../../../models/WalkDefault';
+
+export default function ParticipantsInfo({
+  walksData,
+}: {
+  walksData: WalkDetail;
+}) {
+  return (
+    <article>
+      <h2>
+        참여 중인 강아지 {`${walksData?.pets?.length}/${walksData.capacity}`}
+      </h2>
+      <ul>
+        {walksData.pets == null ? (
+          <span>로딩</span>
+        ) : (
+          walksData.pets.map((pet) => (
+            <li key={pet.petName}>
+              <img
+                src="/main_image.jpg"
+                css={css`
+                  width: 35px;
+                  height: 35px;
+                  object-fit: cover;
+                `}
+                alt={pet.petName}
+              />
+            </li>
+          ))
+        )}
+      </ul>
+    </article>
+  );
+}

--- a/client/components/walks/walksDetail/Title.tsx
+++ b/client/components/walks/walksDetail/Title.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable @next/next/no-img-element */
+import { css } from '@emotion/react';
+import { WalkDetail } from '../../../models/WalkDefault';
+
+export default function Title({ walksData }: { walksData: WalkDetail }) {
+  return (
+    <>
+      <h1>{walksData.title}</h1>
+      <div>
+        <div
+          css={css`
+            width: 35px;
+            height: 35px;
+          `}
+        >
+          <img
+            css={css`
+              width: 100%;
+              height: 100%;
+              object-fit: cover;
+            `}
+            src="/main_image.jpg"
+            alt={`작성자 ${walksData.representMember}사진`}
+          />
+        </div>
+        <p>{walksData.representMember}</p>
+        <p>
+          {walksData.pets == null ? (
+            <span>로딩</span>
+          ) : (
+            walksData.pets.map((pet) =>
+              pet['user.name'] === walksData.representMember ? (
+                <span key={pet.petName}>{pet.petName}</span>
+              ) : null
+            )
+          )}
+        </p>
+      </div>
+    </>
+  );
+}

--- a/client/hooks/WalksDetailQuery.ts
+++ b/client/hooks/WalksDetailQuery.ts
@@ -1,0 +1,20 @@
+import axios from 'axios';
+import { useQuery } from 'react-query';
+import { API } from '../apis/api';
+
+export function useWalksDetailQuery(communityId: string) {
+  const { status, data, error } = useQuery('communityDetail', async () => {
+    const { data } = await axios.get(`${API.COMMUNITYDETAIL}/${communityId}`);
+    return data;
+  });
+
+  if (status === 'loading') {
+    return 'loading';
+  }
+  if (status === 'error') {
+    return error;
+  }
+  if (status === 'success') {
+    return data;
+  }
+}

--- a/client/models/WalkDefault.ts
+++ b/client/models/WalkDefault.ts
@@ -7,3 +7,27 @@ export interface WalkDefault {
   capacity: number;
   participant: number;
 }
+
+export interface WalkDetail extends WalkDefault {
+  communityName: string;
+  body: string;
+  representMember: string;
+  pets: Array<WalkDetailPets>;
+  comments: Array<WalkDetailCommnet>;
+  createdAt: string;
+  viewed: number;
+  liked: number;
+}
+
+interface WalkDetailPets {
+  petName: string;
+  petGender: string;
+  imgUrl: string;
+  'user.name': string;
+}
+
+interface WalkDetailCommnet {
+  comment: string;
+  'user.name': string;
+  createdAt: string;
+}

--- a/client/pages/walks/[walkId]/index.tsx
+++ b/client/pages/walks/[walkId]/index.tsx
@@ -1,15 +1,23 @@
 import { useRouter } from 'next/router';
 import TabTitle from '../../../components/TabTitle';
+import DetailLayout from '../../../components/walks/walksDetail/DetailLayout';
+import Introduce from '../../../components/walks/walksDetail/Introduce';
+
+import { useWalksDetailQuery } from '../../../hooks/WalksDetailQuery';
+import { WalkDetail } from '../../../models/WalkDefault';
 
 export default function Index() {
   const router = useRouter();
   const walkId = router.query.walkId as string;
+  const walksData: WalkDetail = useWalksDetailQuery(walkId);
 
   return (
-    <section>
+    <>
       <TabTitle prefix={walkId} />
-      <h1>산책 개별 페이지 입니다!</h1>
-      <p>walkId = {walkId}</p>
-    </section>
+      <DetailLayout>
+        <h1>산책 개별페이지의 소개 부분입니다!</h1>
+        <Introduce walksData={walksData} />
+      </DetailLayout>
+    </>
   );
 }

--- a/client/pages/walks/[walkId]/notice.tsx
+++ b/client/pages/walks/[walkId]/notice.tsx
@@ -1,7 +1,18 @@
+import { useRouter } from 'next/router';
+import TabTitle from '../../../components/TabTitle';
+import DetailLayout from '../../../components/walks/walksDetail/DetailLayout';
+import MoimNotice from '../../../components/walks/walksDetail/MoimNotice';
+
 export default function Notice() {
+  const router = useRouter();
+  const walkId = router.query.walkId as string;
   return (
-    <section>
-      <h1>산책 개별페이지의 공지사항 부분입니다!</h1>
-    </section>
+    <>
+      <TabTitle prefix={walkId} />
+      <DetailLayout>
+        <h1>산책 개별페이지의 공지사항 부분입니다!</h1>
+        <MoimNotice />
+      </DetailLayout>
+    </>
   );
 }


### PR DESCRIPTION
- 생각보다 복잡한,, 페이지네요. 그래서 컴포넌트 단위로 다 나누었습니다.
- 산책 개별 페이지의 레이아웃을 만들어서 최대한 관리하기 편하게 해봤습니다.
- 송이님이 만들어주신 mockAPI로 데이터를 화면에 출력 했습니다.
- CSS 안 된 상태입니다!

<img width="663" alt="스크린샷 2022-09-19 오후 3 41 24" src="https://user-images.githubusercontent.com/76990149/190962122-f34a2143-d222-4b02-bd09-ba9bd67dec4a.png">
