### PR TITLE
[FEAT] Deploy-Server-Main on AWS

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,12 +1,14 @@
-name: Deploy Test with Gradle on Aws
+name: Deploy - Server with Gradle on Aws
 
 on:
   push:
-    branches: [ "deploy" ]
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 permissions:
   contents: read
-  
+
 env:
   S3_BUCKET_NAME: main026-s3
 
@@ -16,36 +18,46 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        
-    - name: Server Build 
-      run: |                          # 개별 실행 옵션, 없으면 28 ~ 33줄까지 모두 한줄에 실행됨
-        mkdir -p app/server/          # 압축할 임시 폴더 생성 (app/server)
-        cd server/                    # 리포지토리에서 server 폴더로 이동
-        chmod +x ./gradlew            # GitHub Action 에서 gradle build를 위한 권한설정
-        ./gradlew clean bootjar -x test # 테스트를 제외한 빌드 진행, 테스트를 원하면 -x test 옵션 삭제
-        cd ..                         # 리포지토리 기본 위치로 이동
-        cp server/build/libs/*.jar app/server/  # jar 파일 임시 폴더로 복사
-      shell: bash
-  
-    - name: Make zip file
-      run: 
-         zip -r deploy-server.zip ./app      # 임시 폴더 전체 deploy.zip 폴더로 
-      shell: bash
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
 
-    # Access Key와 Secret Access Key를 통해 권한을 확인합니다.
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ap-northeast-2
-    
-    # 압축한 프로젝트를 S3로 전송합니다.
-    - name: Upload to S3
-      run: aws s3 cp --region ap-northeast-2 ./deploy-server.zip s3://$S3_BUCKET_NAME/deploy-server.zip
+      - name: Server Build
+        run: |                          # 개별 실행 옵션, 없으면 28 ~ 33줄까지 모두 한줄에 실행됨
+          mkdir -p deploy-server/          # 압축할 임시 폴더 생성 (deploy-server)
+          cd server/                    # 리포지토리에서 server 폴더로 이동
+          chmod +x ./gradlew            # GitHub Action 에서 gradle build를 위한 권한설정
+          ./gradlew clean bootjar -x test # 테스트를 제외한 빌드 진행, 테스트를 원하면 -x test 옵션 삭제
+          cd ..                         # 리포지토리 기본 위치로 이동
+          cp server/build/libs/*.jar deploy-server/  # jar 파일 임시 폴더로 복사
+        shell: bash
+
+      - name: Make zip file
+        run: |
+          cp appspec.yml deploy-server/appspec.yml
+          cp -r scripts/deploy-aws deploy-server/scripts
+          zip -r deploy-server.zip ./deploy-server      # 임시 폴더 전체 deploy.zip 폴더로
+        shell: bash
+
+      # Access Key와 Secret Access Key를 통해 권한을 확인합니다.
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      # 압축한 프로젝트를 S3로 전송합니다.
+      - name: Upload to S3
+        run: aws s3 cp --region ap-northeast-2 ./deploy-server.zip s3://$S3_BUCKET_NAME/deploy-server.zip
+
+      # CodeDeploy에게 배로 명령을 내립니다.
+      - name: Code Deploy
+        run: >
+          aws deploy create-deployment --application-name main026-deploy-be
+          --deployment-config-name CodeDeployDefault.AllAtOnce
+          --deployment-group-name main026-deploy-group
+          --s3-location bucket=$S3_BUCKET_NAME,bundleType=zip,key=deploy-server.zip

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,20 +26,20 @@ jobs:
           distribution: 'temurin'
 
       - name: Server Build
-        run: |                          # 개별 실행 옵션, 없으면 28 ~ 33줄까지 모두 한줄에 실행됨
-          mkdir -p deploy-server/          # 압축할 임시 폴더 생성 (deploy-server)
-          cd server/                    # 리포지토리에서 server 폴더로 이동
-          chmod +x ./gradlew            # GitHub Action 에서 gradle build를 위한 권한설정
-          ./gradlew clean bootjar -x test # 테스트를 제외한 빌드 진행, 테스트를 원하면 -x test 옵션 삭제
-          cd ..                         # 리포지토리 기본 위치로 이동
-          cp server/build/libs/*.jar deploy-server/  # jar 파일 임시 폴더로 복사
+        run: |                                        # 개별 실행 옵션, 없으면 29 ~ 35줄까지 모두 한줄에 실행됨
+          mkdir -p deploy-server/                     # 압축할 임시 폴더 생성 (deploy-server)
+          cd server/                                  # 리포지토리에서 server 폴더로 이동
+          chmod +x ./gradlew                          # GitHub Action 에서 gradle build를 위한 권한설정
+          ./gradlew clean bootjar -x test             # 테스트를 제외한 빌드 진행, 테스트를 원하면 -x test 옵션 삭제
+          cd ..                                       # 리포지토리 기본 위치로 이동
+          cp server/build/libs/*.jar deploy-server/   # jar 파일 임시 폴더로 복사
         shell: bash
 
       - name: Make zip file
         run: |
           cp appspec.yml deploy-server/appspec.yml
           cp -r scripts/deploy-aws deploy-server/scripts
-          zip -r deploy-server.zip ./deploy-server      # 임시 폴더 전체 deploy.zip 폴더로
+          zip -r deploy-server.zip ./deploy-server        # 임시 폴더 전체 deploy.zip 폴더로
         shell: bash
 
       # Access Key와 Secret Access Key를 통해 권한을 확인합니다.

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,18 @@
+version: 0.0
+os: linux
+files:
+  - source:  /
+    destination: /home/ubuntu/action
+    overwrite: yes
+
+permissions:
+  - object: /
+    pattern: "**"
+    owner: ubuntu
+    group: ubuntu
+
+hooks:
+  ApplicationStart:
+    - location: scripts/deploy.sh
+      timeout: 60
+      runas: ubuntu

--- a/scripts/deploy-aws/deploy.sh
+++ b/scripts/deploy-aws/deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+BUILD_JAR=$(ls /home/ubuntu/action/*.jar)
+JAR_NAME=$(basename $BUILD_JAR)
+
+echo "> 현재 시간: $(date)" >> /home/ubuntu/action/deploy.log
+
+echo "> build 파일명: $JAR_NAME" >> /home/ubuntu/action/deploy.log
+
+echo "> build 파일 복사" >> /home/ubuntu/action/deploy.log
+DEPLOY_PATH=/home/ubuntu/action/
+cp $BUILD_JAR $DEPLOY_PATH
+
+#echo "> 현재 실행중인 애플리케이션 pid 확인" >> /home/ubuntu/action/deploy.log
+#CURRENT_PID=$(pgrep -f $JAR_NAME)
+
+echo "> 8080 PORT 에서 구동중인 애플리케이션 pid 확인"
+CURRENT_PID=$(lsof -ti tcp:8080)
+
+if [ -z $CURRENT_PID ]
+then
+  echo "> 현재 구동중인 애플리케이션이 없으므로 종료하지 않습니다." >> /home/ubuntu/action/deploy.log
+else
+  echo "> kill -15 $CURRENT_PID" >> /home/ubuntu/action/deploy.log
+  kill -15 $CURRENT_PID
+  sleep 5
+fi
+
+
+DEPLOY_JAR=$DEPLOY_PATH$JAR_NAME
+echo "> DEPLOY_JAR 배포"    >> /home/ubuntu/action/deploy.log
+nohup java -jar $DEPLOY_JAR >> /home/ubuntu/deploy.log 2>/home/ubuntu/action/deploy_err.log &


### PR DESCRIPTION
### 개요
- Main Branch에 Push, PR 요청이 들어오면 AWS에 Server 배포를 진행
- Github Action을 통해 Server폴더를 Gradle을 통해 Build
- Github Secret에 등록된 AWS IAM User 정보로 접근하여 빌드된 jar파일, appspec.yml, deploy.sh를 압축하여 s3 버킷에 전송
- Code Deploy를 통해 EC2에 해당 압축파일을 전송하여 deploy.sh를 통해 빌드된 jar파일을 실행

### 변경사항
- Code Deploy : Target Group의 설정 변경을 통해 배포 시간을 단축
- deploy.sh : 8080번 포트를 사용중인 프로세스의 PID를 확인하여 배포시 해당 프로세스를 종료하고 배포대상인 jar을 실행하도록 스크립트 변경