### PR TITLE
[FEAT] 임시 로그인 기능 구현

### DIFF
--- a/client/src/apis/api.ts
+++ b/client/src/apis/api.ts
@@ -6,4 +6,5 @@ export const API = {
   COMMUNITYDETAIL: `${BASE_URL}/community`,
   USERS: `${BASE_URL}/members`,
   PETS: `${BASE_URL}/pets`,
+  Login: `${BASE_URL}/members/login`,
 };

--- a/client/src/components/login/LoginModal.tsx
+++ b/client/src/components/login/LoginModal.tsx
@@ -1,0 +1,252 @@
+import { css, keyframes } from '@emotion/react';
+import { useRouter } from 'next/router';
+import { Dispatch, SetStateAction, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import useLogin from '../../hooks/LoginQuery';
+import { UserLogin } from '../../models/UserLogin';
+import { LoginState } from '../../states/LoginState';
+import UserState from '../../states/UserState';
+import { Theme } from '../../styles/Theme';
+import CommonButton from '../CommonButton';
+
+export default function LoginModal({
+  isLoginModalOpen,
+  setIsLoginModalOpen,
+}: {
+  isLoginModalOpen: boolean;
+  setIsLoginModalOpen: Dispatch<SetStateAction<boolean>>;
+}) {
+  const { handleLogin } = useLogin();
+  const methods = useForm<UserLogin>({
+    mode: 'onChange',
+  });
+
+  const router = useRouter();
+
+  const {
+    register,
+    handleSubmit,
+    setFocus,
+    formState: { errors, isValid },
+    reset,
+  } = methods;
+
+  const [isLoggedIn, setIsLoggedIn] = useRecoilState(LoginState);
+  const setUser = useSetRecoilState(UserState);
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      router.push('/');
+    }
+  }, [isLoggedIn, router]);
+
+  const onClickLogin = async (value: UserLogin) => {
+    try {
+      const res = await handleLogin(value);
+      setUser(res.data);
+      console.log(res);
+      setIsLoggedIn(true);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      if (error.response.data.status === 401) {
+        reset();
+        // backend 에서 메세지를 잘 내려주면 아래 처럼 그걸 출력하고
+        // alert(error.response.data.error);
+        // 아니면 아래처럼 한다.
+        alert('아이디 또는 비밀번호가 일치하지 않습니다.');
+        return;
+      }
+      alert(error.message);
+    }
+  };
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
+
+  useEffect(() => {
+    setFocus('email');
+  }, [setFocus]);
+
+  return (
+    <div
+      className="modal-wrapper"
+      css={modalContainer(isLoginModalOpen)}
+      onClick={() => setIsLoginModalOpen(false)}
+    >
+      <section onClick={(e) => e.stopPropagation()} className="modal">
+        <form>
+          <dl>
+            <label htmlFor="user-email">
+              <dt>이메일</dt>
+              <dd>
+                <input
+                  id="user-email"
+                  type="text"
+                  placeholder="이메일을 입력해주세요"
+                  {...register('email', {
+                    validate: {
+                      empty: (v) =>
+                        (v != null && v !== '') || '이메일을 입력해주세요.',
+                    },
+                    pattern: {
+                      value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                      message: '이메일 형식이 아닙니다.',
+                    },
+                  })}
+                />
+              </dd>
+            </label>
+
+            <dd className="error-area">
+              {errors.email && <p>{errors.email.message}</p>}
+            </dd>
+
+            <label htmlFor="user-password">
+              <dt>비밀번호</dt>
+              <dd>
+                <input
+                  id="user-password"
+                  type="password"
+                  placeholder="비밀번호를 입력해주세요"
+                  {...register('password', {
+                    validate: {
+                      empty: (v) =>
+                        (v != null && v !== '') || '비밀번호를 입력해주세요.',
+                    },
+                  })}
+                />
+              </dd>
+            </label>
+
+            <dd className="error-area">
+              {errors.password && <p>{errors.password.message}</p>}
+            </dd>
+          </dl>
+          <CommonButton
+            type="button"
+            onClick={handleSubmit(onClickLogin)}
+            disabled={!isValid}
+          >
+            로그인
+          </CommonButton>
+        </form>
+      </section>
+    </div>
+  );
+}
+
+const modalContainer = (isLoginModalOpen: boolean) => css`
+  &.modal-wrapper {
+    justify-content: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1;
+    display: flex;
+    align-items: center;
+  }
+
+  &.modal-wrapper section.modal {
+    height: 400px;
+    width: 100%;
+    max-width: 400px;
+    border-radius: 20px;
+    padding: 50px 40px;
+    background-color: #fff;
+    overflow-y: scroll;
+    z-index: 1;
+    margin: 0 20px;
+
+    @media screen and (max-width: 305px) {
+      font-size: 1.1rem;
+      word-break: keep-all;
+    }
+  }
+
+  section.modal {
+    display: ${isLoginModalOpen ? 'block' : 'none'};
+    animation: ${isLoginModalOpen ? fadeIn : fadeOut} 0.3s ease-out;
+  }
+
+  section.modal {
+    h1 {
+      color: ${Theme.mainColor};
+      font-size: 1.5rem;
+      margin-bottom: 40px;
+
+      @media screen and (max-width: 324px) {
+        font-size: 1.2rem;
+        margin-bottom: 10px;
+      }
+    }
+
+    ul {
+      list-style: none;
+    }
+  }
+
+  form dl label {
+    display: grid;
+    grid-template-columns: 1fr 4fr;
+    align-items: center;
+    padding: 20px 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: ${Theme.mainColor};
+    gap: 0px 10px;
+
+    input {
+      width: 100%;
+      height: 100%;
+      padding: 6px 10px;
+    }
+
+    @media screen and (max-width: 464px) {
+      grid-template-columns: 1fr;
+      gap: 10px 0px;
+      padding: 10px 0;
+    }
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+  }
+
+  dd.error-area {
+    height: 20px;
+    text-align: center;
+    color: ${Theme.errorMessagesColor};
+    font-size: 0.9rem;
+  }
+`;
+
+const fadeIn = keyframes`
+  0% {
+    transform: translateY(100%);
+  }
+
+  100% {
+    transform: translateY(0px);
+  }
+`;
+
+const fadeOut = keyframes`
+  0% {
+    transform: translateY(0px);
+  }
+
+  100% {
+    transform: translateY(100%);
+  }
+`;

--- a/client/src/hooks/LoginQuery.ts
+++ b/client/src/hooks/LoginQuery.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+import { API } from '../apis/api';
+import { UserLogin } from '../models/UserLogin';
+
+export default function useLogin() {
+  const handleLogin = async ({ email, password }: UserLogin) => {
+    const res = await axios.post(API.Login, {
+      email,
+      password,
+    });
+    return res;
+  };
+
+  return { handleLogin } as const;
+}

--- a/client/src/models/UserLogin.ts
+++ b/client/src/models/UserLogin.ts
@@ -1,0 +1,4 @@
+export interface UserLogin {
+  email: string;
+  password: string;
+}

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/react';
 import { Icon } from '@iconify/react';
 import Link from 'next/link';
-import { MouseEvent } from 'react';
+import { MouseEvent, useState } from 'react';
 import TabTitle from '../components/TabTitle';
 import LoginButton from '../components/login/LoginButton';
+import LoginModal from '../components/login/LoginModal';
 
 const signupButtonContainer = css`
   display: grid;
@@ -53,10 +54,17 @@ export default function Login() {
     console.log('login button clicked');
   };
 
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+
   return (
     <>
       <TabTitle prefix="로그인" />
-
+      {isLoginModalOpen && (
+        <LoginModal
+          isLoginModalOpen={isLoginModalOpen}
+          setIsLoginModalOpen={setIsLoginModalOpen}
+        />
+      )}
       <section
         css={css`
           min-height: calc(100vh - 75px);
@@ -100,8 +108,11 @@ export default function Login() {
 
           <button
             type="submit"
-            onClick={handleLoginButtonClick}
             css={loginButton('1/2')}
+            onClick={(e) => {
+              e.preventDefault();
+              setIsLoginModalOpen(true);
+            }}
           >
             이메일로 로그인
           </button>

--- a/client/src/states/UserState.ts
+++ b/client/src/states/UserState.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
+const UserState = atom({
+  key: 'UserState',
+  default: {},
+  effects_UNSTABLE: [persistAtom],
+});
+
+export default UserState;


### PR DESCRIPTION
- 완전히 구현된 게 아니라 아직 토큰 관련 로직은 없습니다.

- 일단은 로그인하면 메인 페이지로 이동하고, 콘솔에 유저 관련 응답 찍히게 만들었습니다.

- 리코일 상태에도 유저 데이터 저장해놓았습니다 로컬스토리지에서 확인할 수 있어요!
    - 흑흑 사실 로그인,, 잘 모르겠어용 주말동안 조금 더 공부해서 완성시켜놓겠습니다
    - 비밀번호 유효성 영어숫자 혼합하여 8자리 이상 16자리 이하로 설정했습니다~!