### PR TITLE
[FEAT] AWS S3를 이용한 이미지 처리 기능

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'com.auth0:java-jwt:3.19.2'
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
-
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.307'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0'
 	annotationProcessor(
 			"javax.persistence:javax.persistence-api",

--- a/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Config.java
+++ b/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Config.java
@@ -1,0 +1,31 @@
+package com.main026.walking.util.awsS3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+  @Value("${cloud.aws.credentials.accessKey}")
+  private String accessKey;
+
+  @Value("${cloud.aws.credentials.secretKey}")
+  private String secretKey;
+
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public AmazonS3Client amazonS3Client() {
+    BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+    return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                              .withRegion(region)
+                              .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                              .build();
+  }
+}

--- a/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Controller.java
+++ b/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Controller.java
@@ -1,19 +1,13 @@
 package com.main026.walking.util.awsS3;
 
-import com.amazonaws.util.IOUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLConnection;
 
 @RestController
 @RequestMapping("/s3")
@@ -22,10 +16,35 @@ import java.net.URLConnection;
 public class AwsS3Controller {
   private final AwsS3Service awsS3Service;
 
-//  VPC 내부에서 S3에 접근하려면
   @GetMapping("/{file-name}")
   @ResponseBody
   public ResponseEntity<byte[]> getFile(
+    @PathVariable("file-name") String fileName) throws IOException {
+    log.info("fileName: "+ fileName);
+    return new ResponseEntity<>(awsS3Service.getImageBin(fileName), HttpStatus.OK);
+  }
+
+  @PostMapping
+  public ResponseEntity uploadImage(
+    @RequestPart(name = "file") MultipartFile file
+    ){
+    String fileName = awsS3Service.uploadImage(file);
+    return new ResponseEntity(fileName,HttpStatus.CREATED);
+  }
+
+  @DeleteMapping("/{file-name}")
+  public ResponseEntity deleteImage(
+    @PathVariable("file-name") String fileName
+  ){
+    awsS3Service.deleteImage(fileName);
+    return new ResponseEntity(HttpStatus.NO_CONTENT);
+  }
+
+//  Back-up 메소드 : 한시적으로 IAM User 정보로 보안증명을 완료한 퍼블릭 URL 생성 후 다운받아 리턴하는 메소드
+//  -> VPC Peering등을 통해 이미지서버를 따로 운용하게 되면 사용가능할 듯
+  /*  @GetMapping("/{file-name}")
+  @ResponseBody
+  public ResponseEntity<byte[]> getFileTempPub(
     @PathVariable("file-name") String fileName){
     log.info("fileName: "+ fileName);
     ResponseEntity<byte[]> result = null;
@@ -46,21 +65,5 @@ public class AwsS3Controller {
       log.info("wrong file path");
     }
     return result;
-  }
-
-  @PostMapping
-  public ResponseEntity uploadImage(
-    @RequestPart(name = "file") MultipartFile file
-    ){
-    String fileName = awsS3Service.uploadImage(file);
-    return new ResponseEntity(fileName,HttpStatus.CREATED);
-  }
-
-  @DeleteMapping("/{file-name}")
-  public ResponseEntity deleteImage(
-    @PathVariable("file-name") String fileName
-  ){
-    awsS3Service.deleteImage(fileName);
-    return new ResponseEntity(HttpStatus.NO_CONTENT);
-  }
+  }*/
 }

--- a/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Controller.java
+++ b/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Controller.java
@@ -1,0 +1,66 @@
+package com.main026.walking.util.awsS3;
+
+import com.amazonaws.util.IOUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+
+@RestController
+@RequestMapping("/s3")
+@RequiredArgsConstructor
+@Slf4j
+public class AwsS3Controller {
+  private final AwsS3Service awsS3Service;
+
+//  VPC 내부에서 S3에 접근하려면
+  @GetMapping("/{file-name}")
+  @ResponseBody
+  public ResponseEntity<byte[]> getFile(
+    @PathVariable("file-name") String fileName){
+    log.info("fileName: "+ fileName);
+    ResponseEntity<byte[]> result = null;
+    try {
+      HttpHeaders header = new HttpHeaders();
+
+      // read from S3
+      URL url = new URL(awsS3Service.getFileURL(fileName));
+      HttpURLConnection urlConn = (HttpURLConnection) url.openConnection();
+      InputStream fileIS = urlConn.getInputStream();
+
+      // MIME regardless of extention
+      header.add("Content-Type", URLConnection.guessContentTypeFromStream(fileIS));
+
+      result = new ResponseEntity<>(IOUtils.toByteArray(fileIS), header, HttpStatus.OK);
+
+    } catch(IOException e) {
+      log.info("wrong file path");
+    }
+    return result;
+  }
+
+  @PostMapping
+  public ResponseEntity uploadImage(
+    @RequestPart(name = "file") MultipartFile file
+    ){
+    String fileName = awsS3Service.uploadImage(file);
+    return new ResponseEntity(fileName,HttpStatus.CREATED);
+  }
+
+  @DeleteMapping("/{file-name}")
+  public ResponseEntity deleteImage(
+    @PathVariable("file-name") String fileName
+  ){
+    awsS3Service.deleteImage(fileName);
+    return new ResponseEntity(HttpStatus.NO_CONTENT);
+  }
+}

--- a/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Service.java
+++ b/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Service.java
@@ -4,6 +4,7 @@ import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.S3ObjectResource;
 import com.amazonaws.services.s3.model.*;
+import com.amazonaws.util.IOUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -41,7 +42,6 @@ public class AwsS3Service {
     } catch(IOException e) {
       throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_UPLOAD_FAILED");
     }
-
     return fileName;
   }
 
@@ -78,5 +78,11 @@ public class AwsS3Service {
         .withExpiration(expiration);
 
     return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+  }
+
+  public byte[] getImageBin(String fileName) throws IOException {
+    log.info("INPUT_FILE_NAME" + fileName);
+    S3Object findObject = amazonS3.getObject(bucket,fileName);
+    return IOUtils.toByteArray(findObject.getObjectContent());
   }
 }

--- a/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Service.java
+++ b/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Service.java
@@ -1,0 +1,82 @@
+package com.main026.walking.util.awsS3;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.S3ObjectResource;
+import com.amazonaws.services.s3.model.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AwsS3Service {
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  private final AmazonS3 amazonS3;
+
+  public String uploadImage(MultipartFile file){
+    String fileName = createFileName(file.getOriginalFilename());
+    ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentLength(file.getSize());
+    objectMetadata.setContentType(file.getContentType());
+
+    try(InputStream inputStream = file.getInputStream()) {
+      amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                           .withCannedAcl(CannedAccessControlList.PublicRead));
+    } catch(IOException e) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_UPLOAD_FAILED");
+    }
+
+    return fileName;
+  }
+
+  public void deleteImage(String fileName) {
+    amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
+  }
+
+  private String createFileName(String fileName) {
+    return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+  }
+
+  private String getFileExtension(String fileName) {
+    try {
+      return fileName.substring(fileName.lastIndexOf("."));
+    } catch (StringIndexOutOfBoundsException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_FILE_FORMAT(" + fileName + ")");
+    }
+  }
+
+  // get presigned URL
+  public String getFileURL(String fileName) {
+    log.info("INPUT_FILE_NAME : " + fileName);
+
+    // set expiration
+    Date expiration = new Date();
+    long expTimeMillis = expiration.getTime();
+    expTimeMillis += 1000 * 60 * 60; // 1 hour
+    expiration.setTime(expTimeMillis);
+
+    // Generate the presigned URL.
+    GeneratePresignedUrlRequest generatePresignedUrlRequest =
+      new GeneratePresignedUrlRequest(bucket, (fileName).replace(File.separatorChar, '/'))
+        .withMethod(HttpMethod.GET)
+        .withExpiration(expiration);
+
+    return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+  }
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -10,4 +10,12 @@ file.dir=/Users/kdk/CodeStates/seb39_main_026/server/img/
 jwt.access=main 026 jwt
 jwt.refresh=main 026 refresh
 
-#server.port=9090
+#AWS ????? ????? ?? ??? ?? ??
+server.port=9090
+
+#TODO: github action? ???? ??? ?? ??? ???? ??? ?? ??
+cloud.aws.credentials.accessKey=main026-IAM-accessKey
+cloud.aws.credentials.secretKey=main026-IAM-secretKey
+cloud.aws.s3.bucket=main026-S3-bucketName
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto=false


### PR DESCRIPTION
### 개요
- AWS S3를 이용하여 이미지 업로드, 조회, 삭제 기능 구현
- 메인 로직과 분리된 별도의 컨트롤러(AwsS3Controller) 생성 및 별도 포트(HTTPS:9090)를 사용하여 배포 환경에서 테스트 완료
- 이미지 조회 시 binary 형태로 리턴 (bin to image 변환을 통해 이미지 확인 완료)

### TODO
- AWS IAM 유저 정보를 Github Action을 통해 배포자동화 단계에서 빌드시 application.properties에 입력하는 방법 구현
- 이미지 업로드시 S3 Bucket내에 이미지들을 폴더별로 관리하는 방법 구현