### PR TITLE
[CHORE] 이미지 관련 자잘한 수정 및 검색 쿼리 변경

### DIFF
--- a/client/src/components/DogChoiceModal.tsx
+++ b/client/src/components/DogChoiceModal.tsx
@@ -200,10 +200,7 @@ export default function DogChoiceModal({
               onClick={() => handlePickPetClick(pet.petName)}
               className={pickPets.includes(pet.petName) ? 'pick' : ''}
             >
-              <img
-                src={`${process.env.NEXT_PUBLIC_BASE_URL}/pets/img/${pet.imgUrl}`}
-                alt={`${pet.petName} 사진`}
-              />
+              <img src={pet.imgUrl} alt={`${pet.petName} 사진`} />
               <p>{pet.petName}</p>
             </li>
           ))}

--- a/client/src/components/SearchInput.tsx
+++ b/client/src/components/SearchInput.tsx
@@ -17,7 +17,7 @@ export default function SearchInput({
       if (event.currentTarget.value === '') {
         setQuery('');
       } else {
-        setQuery(`?name=${event.currentTarget.value}`);
+        setQuery(`&name=${event.currentTarget.value}`);
       }
     }
   };

--- a/client/src/components/walks/WalkItem.tsx
+++ b/client/src/components/walks/WalkItem.tsx
@@ -17,11 +17,12 @@ export default function WalkItem({ walk }: { walk: WalkDefault }) {
     border-radius: 15px;
     .img {
       border-radius: 15px 15px 0 0;
+      object-fit: cover;
     }
     .walk_wrapper {
       display: flex;
-      flex-direction: row;
       align-items: center;
+      justify-content: space-between;
       padding: 1rem;
     }
     .walk_info {

--- a/client/src/components/walks/WalksList.tsx
+++ b/client/src/components/walks/WalksList.tsx
@@ -22,11 +22,17 @@ export default function WalksList({ query }: { query: string }) {
   }, [url]);
 
   const walksList = css`
-    display: flex;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: 30% 30% 30%;
+    place-content: center;
     p.alert {
       margin: 2rem;
       color: ${Theme.disableColor};
+    }
+    @media screen and (max-width: 1020px) {
+      display: grid;
+      grid-template-columns: 45% 45%;
+      place-content: center;
     }
     @media screen and (max-width: 768px) {
       display: flex;


### PR DESCRIPTION
### 산책 리스트 렌더 형태 변경

- [x] grid display로 변경
 👽 원래 flex display여서 많은 아이템이 불러와지면 가로폭이 좁아졌습니다
 👽 브라우저 크기를 세 폭으로 나눠서, 폭이 넓어질수록 1-2-3개씩 아이템이 렌더되도록 수정했습니다.

### imgUrl 관련 변경사항

- [x] 기존 /img get 요청 수정
 👽 수정된 이미지가 member.imgUrl 또는 pet.imgUrl로 접근할 수 있게 됨에 따라, 기존 /img 엔드포인트로의 이미지 요청 코드를 수정했습니다.

### 버그 수정

- [x] search query 변경
 👽 검색이 먹히지 않아 확인해봤더니 요청 코드 형식이 바뀌었더라구요. 해당 사항 반영했습니다.