### PR TITLE
[FIX] Community 이미지 기능 개선 및 엔드포인트 컨벤션 통일

### DIFF
--- a/server/src/main/java/com/main026/walking/community/controller/CommunityController.java
+++ b/server/src/main/java/com/main026/walking/community/controller/CommunityController.java
@@ -35,7 +35,7 @@ public class CommunityController {
     // TODO 모임 등록시 모임하는 사람의 펫도 등록
     // TODO 리프레시 토큰 쿠키에다 저장(일단 테스트할때는)
 
-    @PostMapping
+    @PostMapping("/post")
     public ResponseEntity postCommunity(@RequestBody CommunityDto.Post postDto, @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         if(principalDetails==null){
@@ -135,8 +135,8 @@ public class CommunityController {
 
 
     //  CREATE - MULTI
-    @PostMapping("/img/{communityId}")
-    public ResponseEntity postImage(
+    @PostMapping("/image/{communityId}")
+    public ResponseEntity postImageById(
             @PathVariable long communityId,
             @RequestPart List<MultipartFile> imgFile,
             @AuthenticationPrincipal PrincipalDetails principalDetails
@@ -147,8 +147,14 @@ public class CommunityController {
         return new ResponseEntity(savedImages,HttpStatus.CREATED);
     }
 
+    @PostMapping("/post/image")
+    public List<String> postImages(@RequestPart List<MultipartFile> imgFile){
+        imgFile.forEach(awsS3Service::uploadImage);
+        return imgFile.stream().map(MultipartFile::getOriginalFilename).collect(Collectors.toList());
+    }
+
     //  READ
-    @GetMapping("/img/{filename}")
+    @GetMapping("/image/{filename}")
     public ResponseEntity showImage(@PathVariable String filename) throws IOException {
         return new ResponseEntity(awsS3Service.getFileURL(filename),HttpStatus.OK);
     }
@@ -159,7 +165,7 @@ public class CommunityController {
     }
 
     //  UPDATE
-    @PatchMapping("/img/{filename}")
+    @PatchMapping("/image/{filename}")
     public ResponseEntity updateImage(@PathVariable String filename, @RequestPart MultipartFile imgFile, @AuthenticationPrincipal PrincipalDetails principalDetails){
 
         String updatedImage = communityService.updateImage(filename, principalDetails, imgFile);
@@ -168,7 +174,7 @@ public class CommunityController {
     }
 
     //  DELETE
-    @DeleteMapping("/img/{filename}")
+    @DeleteMapping("/image/{filename}")
     public ResponseEntity deleteImage(@PathVariable String filename, @AuthenticationPrincipal PrincipalDetails principalDetails){
         communityService.deleteImage(filename,principalDetails);
         return new ResponseEntity(HttpStatus.NO_CONTENT);

--- a/server/src/main/java/com/main026/walking/community/controller/CommunityController.java
+++ b/server/src/main/java/com/main026/walking/community/controller/CommunityController.java
@@ -150,7 +150,7 @@ public class CommunityController {
     //  READ
     @GetMapping("/img/{filename}")
     public ResponseEntity showImage(@PathVariable String filename) throws IOException {
-        return new ResponseEntity(awsS3Service.getImageBin(filename),HttpStatus.OK);
+        return new ResponseEntity(awsS3Service.getFileURL(filename),HttpStatus.OK);
     }
 
     @GetMapping("/images/{communityId}")

--- a/server/src/main/java/com/main026/walking/community/service/CommunityService.java
+++ b/server/src/main/java/com/main026/walking/community/service/CommunityService.java
@@ -181,7 +181,7 @@ public class CommunityService {
                              .build();
         imageRepository.save(savedImage);
 
-        return uploadImage;
+        return awsS3Service.getFileURL(uploadImage);
         }
 
     //  CREATE - MULTI
@@ -199,9 +199,14 @@ public class CommunityService {
         List<String> findImageNames = findCommunity.getImages().stream().map(Image::getStoreFilename).collect(Collectors.toList());
 
         List<String> findImages = new ArrayList<>();
-        for (String filename : findImageNames) {
-            String imageBin = awsS3Service.getImageBin(filename);
-            findImages.add(imageBin);
+
+        if(!findImageNames.isEmpty()){
+            for (String filename : findImageNames) {
+                String imageBin = awsS3Service.getFileURL(filename);
+                findImages.add(imageBin);
+            }
+        } else {
+            findImages.add(awsS3Service.getFileURL("DEFAULT_COMMUNITY_IMAGE.jpg"));
         }
         return findImages;
     }

--- a/server/src/main/java/com/main026/walking/member/controller/MemberController.java
+++ b/server/src/main/java/com/main026/walking/member/controller/MemberController.java
@@ -65,16 +65,16 @@ public class MemberController {
     }
 
 // CRUD-IMAGE
-    // CREATE : Default Image 적용으로 해당 메소드 삭제
+    // CREATE
     // READ
-    @GetMapping("/img/{memberId}")
+    @GetMapping("/image/{memberId}")
     public ResponseEntity showImage(@PathVariable long memberId) throws IOException {
         String findImage = memberService.findImage(memberId);
         return new ResponseEntity(awsS3Service.getFileURL(findImage),HttpStatus.OK);
     }
 
     //  UPDATE
-    @PatchMapping("/img/{memberId}")
+    @PatchMapping("/image/{memberId}")
     public ResponseEntity patchImage(@PathVariable long memberId,
                              @RequestPart MultipartFile imgFile,
                              @AuthenticationPrincipal PrincipalDetails principalDetails){
@@ -90,7 +90,7 @@ public class MemberController {
 
 
     //  DELETE
-    @DeleteMapping("/img/{memberId}")
+    @DeleteMapping("/image/{memberId}")
     public ResponseEntity deleteImage(@PathVariable long memberId,
                                       @AuthenticationPrincipal PrincipalDetails principalDetails){
         authorization(memberId,principalDetails);

--- a/server/src/main/java/com/main026/walking/member/controller/MemberController.java
+++ b/server/src/main/java/com/main026/walking/member/controller/MemberController.java
@@ -70,7 +70,7 @@ public class MemberController {
     @GetMapping("/img/{memberId}")
     public ResponseEntity showImage(@PathVariable long memberId) throws IOException {
         String findImage = memberService.findImage(memberId);
-        return new ResponseEntity(awsS3Service.getImageBin(findImage),HttpStatus.OK);
+        return new ResponseEntity(awsS3Service.getFileURL(findImage),HttpStatus.OK);
     }
 
     //  UPDATE

--- a/server/src/main/java/com/main026/walking/member/service/MemberService.java
+++ b/server/src/main/java/com/main026/walking/member/service/MemberService.java
@@ -54,7 +54,7 @@ public class MemberService {
         memberRepository.save(member);
 
         MemberDto.Response dto = memberMapper.memberToMemberResponseDto(member);
-        dto.setImgUrl(awsS3Service.getImageBin(dto.getImgUrl()));
+        dto.setImgUrl(awsS3Service.getFileURL(dto.getImgUrl()));
         return dto;
     }
 

--- a/server/src/main/java/com/main026/walking/pet/controller/PetController.java
+++ b/server/src/main/java/com/main026/walking/pet/controller/PetController.java
@@ -97,7 +97,7 @@ public class PetController {
     @GetMapping("/img/{petId}")
     public ResponseEntity showImage(@PathVariable long petId) throws IOException {
         String findImage = petService.findImageById(petId);
-        return new ResponseEntity(awsS3Service.getImageBin(findImage), HttpStatus.OK);
+        return new ResponseEntity(awsS3Service.getFileURL(findImage), HttpStatus.OK);
     }
 
     //  DELETE

--- a/server/src/main/java/com/main026/walking/pet/controller/PetController.java
+++ b/server/src/main/java/com/main026/walking/pet/controller/PetController.java
@@ -74,7 +74,7 @@ public class PetController {
     }
 
 //    CRUD-IMAGE
-    //  CREATE : DEFAULT_IMAGE 적용으로 메소드 삭제
+    //  CREATE
     @PostMapping("/post/image")
     public String postImage(@RequestPart MultipartFile imgFile){
         if(imgFile.isEmpty()) {
@@ -85,7 +85,7 @@ public class PetController {
     }
 
     //  UPDATE
-    @PatchMapping("/img/{petId}")
+    @PatchMapping("/image/{petId}")
     public ResponseEntity patchImage(@PathVariable long petId,
                                      @RequestPart MultipartFile imgFile,
                                      @AuthenticationPrincipal PrincipalDetails principalDetails) throws IOException {
@@ -94,14 +94,14 @@ public class PetController {
     }
 
     //  READ
-    @GetMapping("/img/{petId}")
+    @GetMapping("/image/{petId}")
     public ResponseEntity showImage(@PathVariable long petId) throws IOException {
         String findImage = petService.findImageById(petId);
         return new ResponseEntity(awsS3Service.getFileURL(findImage), HttpStatus.OK);
     }
 
     //  DELETE
-    @DeleteMapping("/img/{petId}")
+    @DeleteMapping("/image/{petId}")
     public ResponseEntity deleteImage(
       @PathVariable long petId,
       @AuthenticationPrincipal PrincipalDetails principalDetails) throws IOException {

--- a/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Service.java
+++ b/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Service.java
@@ -77,15 +77,13 @@ public class AwsS3Service {
       new GeneratePresignedUrlRequest(bucket, (fileName).replace(File.separatorChar, '/'))
         .withMethod(HttpMethod.GET)
         .withExpiration(expiration);
-
+    log.info(" [S3-Get] Read-File-Name : " + fileName);
     return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
   }
 
   public String getImageBin(String fileName) throws IOException {
-//    S3Object findObject = amazonS3.getObject(bucket,fileName);
+    S3Object findObject = amazonS3.getObject(bucket,fileName);
     log.info(" [S3-Get] Read-File-Name : " + fileName);
-//    return Base64.encodeAsString(findObject.getObjectContent().readAllBytes());
-//    return IOUtils.toByteArray(findObject.getObjectContent());
-    return getFileURL(fileName);
+    return Base64.encodeAsString(findObject.getObjectContent().readAllBytes());
   }
 }


### PR DESCRIPTION
### 개요
- Community 조회시 저장된 이미지가 없으면 Default Image URL로 응답합니다.
- Community 등록시 post/image로 등록할 이미지를 S3에 등록 후 파일명을 리턴받아 입력하여 모임을 생성합니다.

### 변경사항
- 응답방식을 pre-signed URL로 결정하여 AwsS3Service의 메소드를 일원화했습니다.
- 엔드포인트 컨벤션을 일관성있게 수정하였습니다.