### PR TITLE
[FEAT] 비밀번호 찾기 기능 구현

### DIFF
--- a/client/src/components/login/PasswordModal.tsx
+++ b/client/src/components/login/PasswordModal.tsx
@@ -1,0 +1,189 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { css, keyframes } from '@emotion/react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useFindPasswordMutation } from '../../hooks/FindPasswordquery';
+import { Theme } from '../../styles/Theme';
+import CommonButton from '../CommonButton';
+
+export default function PasswordModal({
+  isPasswordModalOpen,
+  setIsPasswordModalOpen,
+}: {
+  isPasswordModalOpen: boolean;
+  setIsPasswordModalOpen: Dispatch<SetStateAction<boolean>>;
+}) {
+  const methods = useForm<{ email: string }>({
+    mode: 'onChange',
+  });
+  const { mutate: findPasswordMutate } = useFindPasswordMutation();
+
+  const {
+    register,
+    handleSubmit,
+    setFocus,
+    formState: { errors, isValid },
+  } = methods;
+
+  const [responseErr, setResponseErr] = useState('');
+
+  const onClickPassword = (value: { email: string }) => {
+    findPasswordMutate(value, {
+      onSuccess: () => setResponseErr('임시 비밀번호가 발급되었습니다.'),
+      onError: (err: any) => {
+        if (err.response.status === 404) {
+          setResponseErr('존재하지 않는 이메일입니다.');
+        }
+      },
+    });
+  };
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
+
+  useEffect(() => {
+    setFocus('email');
+  }, [setFocus]);
+
+  return (
+    <div
+      className="modal-wrapper"
+      css={modalContainer(isPasswordModalOpen)}
+      onClick={() => setIsPasswordModalOpen(false)}
+    >
+      <section onClick={(e) => e.stopPropagation()} className="modal">
+        <form>
+          <label htmlFor="user-email">
+            <input
+              id="user-email"
+              type="text"
+              placeholder="이메일을 입력해주세요"
+              {...register('email', {
+                onChange: () => setResponseErr(''),
+                validate: {
+                  empty: (v) =>
+                    (v != null && v !== '') || '이메일을 입력해주세요.',
+                },
+                pattern: {
+                  value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                  message: '이메일 형식이 아닙니다.',
+                },
+              })}
+            />
+          </label>
+          <span className="error-area">
+            {errors.email && <p>{errors.email.message}</p>}
+            {responseErr}
+          </span>
+          <CommonButton
+            type="button"
+            disabled={!isValid}
+            onClick={handleSubmit(onClickPassword)}
+          >
+            임시 비밀번호 발급
+          </CommonButton>
+        </form>
+      </section>
+    </div>
+  );
+}
+
+const modalContainer = (isLoginModalOpen: boolean) => css`
+  &.modal-wrapper {
+    justify-content: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1;
+    display: flex;
+    align-items: center;
+  }
+
+  &.modal-wrapper section.modal {
+    height: 300px;
+    width: 100%;
+    max-width: 400px;
+    border-radius: 20px;
+    padding: 50px 40px;
+    background-color: #fff;
+    overflow-y: scroll;
+    z-index: 1;
+
+    @media screen and (max-width: 305px) {
+      font-size: 1.1rem;
+      word-break: keep-all;
+    }
+  }
+
+  section.modal {
+    display: ${isLoginModalOpen ? 'block' : 'none'};
+    animation: ${isLoginModalOpen ? fadeIn : fadeOut} 0.3s ease-out;
+  }
+
+  form label {
+    padding: 20px 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: ${Theme.mainColor};
+    gap: 0px 10px;
+
+    input {
+      width: 100%;
+      height: 100%;
+      padding: 6px 10px;
+      border: 0;
+      border-bottom: 1px solid ${Theme.divisionLineColor};
+      :focus {
+        outline: none;
+      }
+    }
+
+    @media screen and (max-width: 464px) {
+      grid-template-columns: 1fr;
+      gap: 10px 0px;
+      padding: 10px 0;
+    }
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    height: 100%;
+  }
+
+  .error-area {
+    height: 10px;
+    text-align: center;
+    color: ${Theme.errorMessagesColor};
+    font-size: 0.8rem;
+    margin-bottom: 1.3rem;
+  }
+`;
+
+const fadeIn = keyframes`
+  0% {
+    transform: translateY(100%);
+  }
+
+  100% {
+    transform: translateY(0px);
+  }
+`;
+
+const fadeOut = keyframes`
+  0% {
+    transform: translateY(0px);
+  }
+
+  100% {
+    transform: translateY(100%);
+  }
+`;

--- a/client/src/components/users/PetEditInfo.tsx
+++ b/client/src/components/users/PetEditInfo.tsx
@@ -10,7 +10,6 @@ import React, {
   useCallback,
   Dispatch,
   SetStateAction,
-  useEffect,
 } from 'react';
 import { useRecoilState } from 'recoil';
 import { API } from '../../apis/api';
@@ -224,10 +223,6 @@ export default function PetEditInfo({
       }
     }
   `;
-
-  useEffect(() => {
-    console.log(pet);
-  }, []);
 
   return (
     <div css={petInfo}>

--- a/client/src/components/users/PetEditInfo.tsx
+++ b/client/src/components/users/PetEditInfo.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@iconify/react';
 
 import axios from 'axios';
 import Image from 'next/image';
+import Router from 'next/router';
 import React, {
   useState,
   useRef,
@@ -72,7 +73,6 @@ export default function PetEditInfo({
       birthDay: petBirthday,
       imgUrl: petImgUrl,
     };
-    console.log(editedData);
     if (pet.id === 909090) {
       axios.post(`${API.PETS}/post/?username=${user.username}`, editedData, {
         headers: {
@@ -89,6 +89,7 @@ export default function PetEditInfo({
       });
     }
     setIsPetEditMode(false);
+    Router.reload();
   };
 
   const handleDeleteClick = () => {

--- a/client/src/hooks/FindPasswordquery.ts
+++ b/client/src/hooks/FindPasswordquery.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { useMutation } from 'react-query';
+
+export const useFindPasswordMutation = () => {
+  return useMutation(async (email: { email: string }) => {
+    await axios.post(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/members/findpassword`,
+      email
+    );
+  });
+};

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -5,6 +5,7 @@ import { MouseEvent, useState } from 'react';
 import TabTitle from '../components/TabTitle';
 import LoginButton from '../components/login/LoginButton';
 import LoginModal from '../components/login/LoginModal';
+import PasswordModal from '../components/login/PasswordModal';
 
 const signupButtonContainer = css`
   display: grid;
@@ -54,7 +55,13 @@ export default function Login() {
     console.log('login button clicked');
   };
 
+  const handlePasswordButtonClick = (event: MouseEvent) => {
+    event.preventDefault();
+    setIsPasswordModalOpen(!isPasswordModalOpen);
+  };
+
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+  const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
 
   return (
     <>
@@ -63,6 +70,12 @@ export default function Login() {
         <LoginModal
           isLoginModalOpen={isLoginModalOpen}
           setIsLoginModalOpen={setIsLoginModalOpen}
+        />
+      )}
+      {isPasswordModalOpen && (
+        <PasswordModal
+          isPasswordModalOpen={isPasswordModalOpen}
+          setIsPasswordModalOpen={setIsPasswordModalOpen}
         />
       )}
       <section
@@ -118,7 +131,7 @@ export default function Login() {
           </button>
           <button
             type="submit"
-            onClick={handleLoginButtonClick}
+            onClick={handlePasswordButtonClick}
             css={loginButton('3/4')}
           >
             비밀번호 찾기


### PR DESCRIPTION
### 비밀번호 찾기 기능 구현

- [x] /login 페이지에서 비밀번호 찾기 버튼을 누르면 비밀번호 찾기 모달이 뜹니다.
 👽 유효한 이메일 형식이 아닐 시 에러 메시지가 뜹니다.
 👽 제출 후 가입한 이메일이 아닐 시 에러 메시지가 뜹니다.
 👽 아직 서버가 success 응답을 반환하지 않지만, 만약 반환하게 된다면 '임시 비밀번호가 발급되었습니다'라는 문구가 뜨게 됩니다.

<img width="475" alt="스크린샷 2022-09-30 오후 4 05 18" src="https://user-images.githubusercontent.com/98731086/193211068-ab9f88ad-0743-4109-b3b3-554d1eef4207.png">

### 강아지 등록 시 바로 반영

- [x] 강아지를 등록하면 라우터가 리로드 되어 화면에 등록한 강아지가 바로 보여지게 됩니다.
 👽 react query를 이용해 페이지 리로드 없이도 바로 반영할 수 있는 방법이 있는 것 같은데, 차후 반영해볼게요!
