### PR TITLE
[FEAT] 회원 탈퇴 기능 구현

### DIFF
--- a/client/src/components/users/DeleteUserButton.tsx
+++ b/client/src/components/users/DeleteUserButton.tsx
@@ -1,0 +1,43 @@
+import { css } from '@emotion/react';
+import { useRouter } from 'next/router';
+import { useRecoilState } from 'recoil';
+import { useDeleteUserMutation } from '../../hooks/UsersQuery';
+import { LoginState } from '../../states/LoginState';
+import UserState from '../../states/UserState';
+import { Theme } from '../../styles/Theme';
+
+export default function DeleteUserButton({ id }: { id: string }) {
+  const { mutate: deleteUserMutate } = useDeleteUserMutation();
+  const [, setIsLogin] = useRecoilState(LoginState);
+  const [, setUserState] = useRecoilState(UserState);
+  const router = useRouter();
+
+  const handleDeleteUser = () => {
+    deleteUserMutate(id, {
+      onSuccess: () => {
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        localStorage.removeItem('userId');
+        localStorage.removeItem('currentAddress');
+        setIsLogin(false);
+        setUserState(null);
+        router.push('/');
+      },
+    });
+  };
+
+  const deleteUser = css`
+    cursor: pointer;
+    background-color: transparent;
+    border: 0;
+    color: ${Theme.divisionLineColor};
+    position: relative;
+    float: right;
+    margin-top: 0.5rem;
+  `;
+  return (
+    <button css={deleteUser} type="button" onClick={handleDeleteUser}>
+      회원탈퇴
+    </button>
+  );
+}

--- a/client/src/hooks/UsersQuery.ts
+++ b/client/src/hooks/UsersQuery.ts
@@ -61,3 +61,14 @@ export const useUpdateUserImgMutation = () => {
     }
   );
 };
+
+export const useDeleteUserMutation = () => {
+  return useMutation(async (id: string) => {
+    await axios.delete(`${process.env.NEXT_PUBLIC_BASE_URL}/members/${id}`, {
+      headers: {
+        authorization: localStorage.getItem('accessToken') || '',
+        refresh_token: localStorage.getItem('refreshToken') || '',
+      },
+    });
+  });
+};

--- a/client/src/pages/users/[userId].tsx
+++ b/client/src/pages/users/[userId].tsx
@@ -4,6 +4,7 @@ import { GetServerSideProps } from 'next';
 import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import TabTitle from '../../components/TabTitle';
+import DeleteUserButton from '../../components/users/DeleteUserButton';
 import LogoutButton from '../../components/users/LogoutButton';
 import PetInfo from '../../components/users/PetInfo';
 import UserInfo from '../../components/users/UserInfo';
@@ -72,7 +73,19 @@ export default function User({ userId }: { userId: string }) {
           <WalksInfo walks={getUsersQuery.data?.memberCommunityList} />
         </>
       )}
-      <footer>{isValidated && <LogoutButton />}</footer>
+      <footer
+        css={css`
+          display: flex;
+          flex-direction: column;
+          align-items: flex-end;
+        `}
+      >
+        {isValidated && (
+          <>
+            <LogoutButton /> <DeleteUserButton id={userId} />
+          </>
+        )}
+      </footer>
     </section>
   );
 }


### PR DESCRIPTION
### 회원 탈퇴 기능

- [x] 이제 마이페이지에서 회원 탈퇴를 할 수 있습니다
 👽 회원 탈퇴가 성공하면, 로컬스토리지의 모든 정보들이 리셋(로그아웃 처리)됩니다.
 👽 탈퇴 시, 아무 경고창 없이 바로 탈퇴가 되는데 이 부분은 천천히 수정할게요!
 👽 탈퇴 완료 시 '탈퇴가 완료되었습니다' 라고 써있는 페이지로 이동하면 좋을 것 같아서, 해당 페이지도 만들어서 추가해보려고 합니다.