### PR TITLE
[FIX] Image 관련 오류 수정

### DIFF
--- a/server/src/main/java/com/main026/walking/member/service/MemberService.java
+++ b/server/src/main/java/com/main026/walking/member/service/MemberService.java
@@ -54,7 +54,6 @@ public class MemberService {
         memberRepository.save(member);
 
         MemberDto.Response dto = memberMapper.memberToMemberResponseDto(member);
-        dto.setImgUrl(awsS3Service.getFileURL(dto.getImgUrl()));
         return dto;
     }
 

--- a/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Service.java
+++ b/server/src/main/java/com/main026/walking/util/awsS3/AwsS3Service.java
@@ -48,8 +48,11 @@ public class AwsS3Service {
   }
 
   public void deleteImage(String fileName) {
-    amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
-    log.info(" [S3-Delete] Deleted-File-Name : " + fileName);  }
+//    TODO
+//    IAM 유저 권한 : S3FullAccess + S3 버킷 : S3:* 권한으로도 삭제만 안됨
+//    Patch 구동을 위해 S3 Delete 메소드 비활성화
+//    amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
+    log.info(" [S3-Delete] Deleted-File-Name : " + fileName + " [Not Implement]");  }
 
   private String createFileName(String fileName) {
     return UUID.randomUUID().toString().concat(getFileExtension(fileName));


### PR DESCRIPTION
### 개요
- 회원 등록시 imgUrl 이 AwsS3Service로 이중 매핑 되는 오류를 발견하여 수정하였습니다.
- 이미지 삭제 과정 중 S3에서 권한 관련 오류가 발생하여 임시적으로 비활성화 하였습니다.

### 변경사항
- AwsS3Service의 Delete 메소드에서 권한 관련 오류가 발생하여 해결 중에 있습니다.
- AwsS3Service - Delete 메소드를 사용하는 이미지 Patch, Delete 요청시 계속해서 위와 관련한 오류가 발생함에 따라 해당 메소드를 임시적으로 비활성화하였습니다.
- Patch, Delete 요청 시 삭제 대상이 DB나 응답에서는 삭제되나 S3에서는 삭제되지 않습니다.