### PR TITLE
[FIX] 모임참여 관련 오류 수정

### DIFF
--- a/server/src/main/java/com/main026/walking/community/service/CommunityService.java
+++ b/server/src/main/java/com/main026/walking/community/service/CommunityService.java
@@ -95,11 +95,21 @@ public class CommunityService {
     }
 
     public CommunityDto.Response joinPet(Long communityId, List<Long> petIdList) {
+        //일단 커뮤니티 소환
         Community community = communityRepository.findById(communityId).orElseThrow();
         //참여가능 여부 검사
         isFull(community.getCapacity(),community.getCommunityPets().size(),petIdList.size());
+        //커뮤니티에 이미 속해있는 강아지 id 리스트 소환
+        List<Long> communityPetIdList = community.getCommunityPets()
+                .stream().map(p -> p.getPet().getId()).collect(Collectors.toList());
 
+        //TODO 같은애들이 계속가입됨
         for (Long petId : petIdList) {
+            //가입하려는 애가 이미 있으면 건너뛰기
+            if(communityPetIdList.contains(petId)){
+                continue;
+//                new BusinessLogicException(ExceptionCode.PET_EXISTS);
+            }
             Pet pet = petRepository.findById(petId).orElseThrow();
             CommunityPet communityPet = CommunityPet.builder()
                     .pet(pet)

--- a/server/src/main/java/com/main026/walking/exception/ExceptionCode.java
+++ b/server/src/main/java/com/main026/walking/exception/ExceptionCode.java
@@ -7,6 +7,7 @@ public enum ExceptionCode {
     USERNAME_EXISTS(409, "Username already exists"),
     MEMBER_NOT_FOUND(404, "Member not found"),
     PET_NOT_FOUND(404, "Pet not found"),
+    PET_EXISTS(409,"Pet already joined"),
     NO_AUTHORIZATION(401,"You don't have authority"),
     INVALID_AUTHORIZATION(401,"Authorization is invalid"),
     FILE_NOT_FOUND(404,"Can not found attached file"),

--- a/server/src/main/java/com/main026/walking/member/mapper/MemberMapper.java
+++ b/server/src/main/java/com/main026/walking/member/mapper/MemberMapper.java
@@ -49,7 +49,6 @@ public abstract class MemberMapper {
     // TODO
     //  멤버의 펫이 가입한 모임 정보를 출력
     //이..게...맞나...?
-    //펫을 조회해서 모임도 함께보여주는것이 더 간단하긴하다.
     List<CommunityDto.compactResponse> communityList = new ArrayList<>();
     for (int i = 0; i < member.getPetList().size(); i++) {
       for (int j = 0; j < member.getPetList().get(i).getCommunityPets().size(); j++) {
@@ -57,7 +56,9 @@ public abstract class MemberMapper {
         Community community = member.getPetList().get(i).getCommunityPets().get(j).getCommunity();
         CommunityDto.compactResponse compactResponse = new CommunityDto.compactResponse(community);
         compactResponse.setRepresentImgUrls(awsS3Service.getFileURL(compactResponse.getRepresentImgUrls()));
-        if (!communityList.contains(compactResponse)){
+
+        List<Long> communityIdList = communityList.stream().map(c -> c.getCommunityId()).collect(Collectors.toList());
+        if (!communityIdList.contains(compactResponse.getCommunityId())){
           communityList.add(compactResponse);
         }
       }


### PR DESCRIPTION
- 회원가입->로그인->강아지등록->모임가입->모임,강아지,회원 상세조회 순으로 정상작동 확인했습니다.
- 회원 조회시 강아지가 가입한 모임이 중복으로 출력되는 것을 수정했습니다.
- 동일한 강아지가 모임가입요청시, 혹은 이미 가입한 강아지와 가입하지않은 강아지를 같이 선택하면
가입하지 않은 강아지만 가입되게 했습니다. 