### PR TITLE
[FIX] Community Post Dto : images -> imgUrls 로 변경

### DIFF
--- a/server/src/main/java/com/main026/walking/community/dto/CommunityDto.java
+++ b/server/src/main/java/com/main026/walking/community/dto/CommunityDto.java
@@ -25,7 +25,7 @@ public class CommunityDto {
     public static class Post {
         private String name;
 
-        private List<String> images = new ArrayList<>();
+        private List<String> imgUrls = new ArrayList<>();
 
         /**
          * 시,구,동을 받아야하는데 나눠서 받는 방법 외에 또 있을까?

--- a/server/src/main/java/com/main026/walking/community/service/CommunityService.java
+++ b/server/src/main/java/com/main026/walking/community/service/CommunityService.java
@@ -78,7 +78,7 @@ public class CommunityService {
 
         //이미지 세팅
         Community savedCommunity = communityRepository.save(community);
-        List<String> imagePaths = postDto.getImages();
+        List<String> imagePaths = postDto.getImgUrls();
 
         for (String imagePath : imagePaths) {
             Image image = Image.builder()


### PR DESCRIPTION
### 개요
- 다른 객체들과의 네이밍 컨벤션을 맞추기 위해 Community Post 요청시 Dto의 이미지 필드명을 imgUrls로 수정하였습니다.