### PR TITLE
[FEAT] 모임 작성 페이지에서 이미지 추가 기능

### DIFF
--- a/client/src/components/login/LoginModal.tsx
+++ b/client/src/components/login/LoginModal.tsx
@@ -35,12 +35,6 @@ export default function LoginModal({
   const [isLoggedIn, setIsLoggedIn] = useRecoilState(LoginState);
   const setUser = useSetRecoilState(UserState);
 
-  useEffect(() => {
-    if (isLoggedIn) {
-      router.push('/');
-    }
-  }, [isLoggedIn, router]);
-
   const onClickLogin = async (value: UserLogin) => {
     try {
       const user = await handleLogin(value);
@@ -65,6 +59,13 @@ export default function LoginModal({
       alert(error.message);
     }
   };
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      router.push('/');
+    }
+  }, [isLoggedIn, router]);
+
   useEffect(() => {
     document.body.style.overflow = 'hidden';
     return () => {

--- a/client/src/components/walks/Carousel.tsx
+++ b/client/src/components/walks/Carousel.tsx
@@ -17,6 +17,10 @@ const imgCarouselContainer = (
     height: 300px;
   }
 
+  @media screen and (max-width: 385px) {
+    height: 200px;
+  }
+
   position: relative;
   overflow: hidden;
   height: 200px;

--- a/client/src/components/walks/Carousel.tsx
+++ b/client/src/components/walks/Carousel.tsx
@@ -14,11 +14,12 @@ const imgCarouselContainer = (
   }
 
   @media screen and (max-width: 600px) {
-    height: unset;
+    height: 300px;
   }
 
   position: relative;
   overflow: hidden;
+  height: 200px;
   height: ${carouselDefaultHeight};
   width: 100%;
 
@@ -36,8 +37,8 @@ const imgCarouselContainer = (
 
   section {
     display: flex;
+    min-width: 100%;
     height: 100%;
-    align-items: center;
     transform: translateX(-${index * 100}%);
 
     img {
@@ -69,10 +70,10 @@ const imgCarouselContainer = (
 `;
 
 export default function Carousel({
-  // walkDetail,
+  walkDetail,
   carouselDefaultHeight,
 }: {
-  walkDetail: WalkDetail;
+  walkDetail?: WalkDetail;
   carouselDefaultHeight?: string;
 }) {
   const [imgCarouselIndex, setImgCarouselIndex] = useState(0);
@@ -80,26 +81,24 @@ export default function Carousel({
   const [slideEnd, setSlideEnd] = useState(0);
 
   const handleCarouselButtonClick = (type: string) => {
-    if (type === 'next') {
-      // if (imgCarouselIndex === walkDetail.imgUrls.length - 1) {
-      if (imgCarouselIndex === 2) {
-        return;
-      } else {
-        setImgCarouselIndex(imgCarouselIndex + 1);
-      }
-    } else if (type === 'prev') {
-      if (imgCarouselIndex === 0) {
-        return;
-      } else {
-        setImgCarouselIndex(imgCarouselIndex - 1);
+    if (walkDetail) {
+      if (type === 'next') {
+        if (imgCarouselIndex === walkDetail.imgUrls.length - 1) {
+          return;
+        } else {
+          setImgCarouselIndex(imgCarouselIndex + 1);
+        }
+      } else if (type === 'prev') {
+        if (imgCarouselIndex === 0) {
+          return;
+        } else {
+          setImgCarouselIndex(imgCarouselIndex - 1);
+        }
       }
     }
   };
 
   const handleCarouselSlide = () => {
-    console.log('slideStart', slideStart);
-    console.log('slideEnd', slideEnd);
-    console.log(slideStart - slideEnd);
     if (slideEnd === 0 || slideStart === 0) {
       return;
     }
@@ -116,8 +115,7 @@ export default function Carousel({
       css={imgCarouselContainer(imgCarouselIndex, carouselDefaultHeight)}
     >
       <p>
-        {/* {imgCarouselIndex + 1} / {walkDetail.imgUrls.length} */}
-        {imgCarouselIndex + 1} / 3
+        {imgCarouselIndex + 1} / {walkDetail?.imgUrls.length}
       </p>
       <section
         onTouchStart={(e) => {
@@ -128,26 +126,33 @@ export default function Carousel({
           handleCarouselSlide();
         }}
       >
-        {/* {walkDetail.imgUrls.map((img) => (
-          <img src={img} alt="walk" key={img} />
-        ))} */}
-        <img
-          src="https://cdn.pixabay.com/photo/2022/08/21/21/24/colours-7402147_960_720.jpg"
-          alt="기타치는 할아버지"
-        />
-        <img
-          src="https://cdn.pixabay.com/photo/2019/08/19/07/45/corgi-4415649_960_720.jpg"
-          alt="코기"
-        />
-        <img
-          src="https://cdn.pixabay.com/photo/2016/03/27/20/51/dogs-1284238_960_720.jpg"
-          alt="자고 있는 겸둥이 강쥐들"
-        />
+        {walkDetail?.imgUrls.map((img) => (
+          <div
+            key={img}
+            css={css`
+              min-width: 100%;
+            `}
+          >
+            <img src={img} alt="walk" />
+          </div>
+        ))}
       </section>
-      <button onClick={() => handleCarouselButtonClick('prev')}>
+      <button
+        onClick={() => handleCarouselButtonClick('prev')}
+        css={css`
+          display: ${imgCarouselIndex === 0 ? 'none' : 'block'};
+        `}
+      >
         <Icon icon="ooui:next-rtl" />
       </button>
-      <button onClick={() => handleCarouselButtonClick('next')}>
+      <button
+        onClick={() => handleCarouselButtonClick('next')}
+        css={css`
+          display: ${imgCarouselIndex + 1 === walkDetail?.imgUrls.length
+            ? 'none'
+            : 'block'};
+        `}
+      >
         <Icon icon="ooui:next-ltr" />
       </button>
     </article>

--- a/client/src/components/walks/wirte/ImageUploadZone.tsx
+++ b/client/src/components/walks/wirte/ImageUploadZone.tsx
@@ -1,0 +1,127 @@
+/* eslint-disable @next/next/no-img-element */
+import { css } from '@emotion/react';
+import { Icon } from '@iconify/react';
+import { Theme } from '../../../styles/Theme';
+
+const imageUploadZoneContainer = css`
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  overflow: scroll;
+  padding-bottom: 16px;
+
+  li {
+    width: 150px;
+    min-width: 150px;
+    height: 200px;
+    background-color: #f7f7f5;
+    border-radius: 15px;
+    padding: 10px;
+
+    input[type='file'] {
+      display: none;
+    }
+
+    label {
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      height: 100%;
+      cursor: pointer;
+    }
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+
+  li.image-box {
+    position: relative;
+
+    .image-delete-button {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      font-size: 1.4rem;
+      color: ${Theme.mainColor};
+      cursor: pointer;
+    }
+  }
+`;
+
+export default function ImageUploadZone({
+  moimImages,
+  setMoimImages,
+}: {
+  moimImages: File[];
+  setMoimImages: React.Dispatch<React.SetStateAction<File[]>>;
+}) {
+  // 이미지 관련
+  const handleMoimImageChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    if (event.target.files) {
+      const imageFile = event.target.files;
+
+      if (imageFile['length'] > 3) {
+        alert('이미지는 최대 3개까지 등록 가능합니다.');
+        return;
+      }
+      if (moimImages.length > 2) {
+        alert('이미지는 최대 3개까지 등록 가능합니다.');
+        return;
+      }
+      if (moimImages.length + imageFile['length'] > 3) {
+        alert('이미지는 최대 3개까지 등록 가능합니다.');
+        return;
+      } else {
+        setMoimImages([...moimImages, ...Array.from(imageFile)]);
+      }
+    }
+  };
+
+  return (
+    <>
+      <label
+        css={css`
+          font-size: 1.1rem;
+          font-weight: 600;
+        `}
+      >
+        모임의 대표 사진을 올려주세요.
+      </label>
+      <ul css={imageUploadZoneContainer}>
+        <li>
+          <label htmlFor="moimImage">
+            <Icon icon="ant-design:camera-twotone" className="camera" />
+            <p>{moimImages.length} / 3</p>
+          </label>
+          <input
+            id="moimImage"
+            multiple
+            type="file"
+            accept="image/*"
+            onChange={(e) => handleMoimImageChange(e)}
+          />
+        </li>
+        {moimImages.map((image, index) => (
+          <li key={`${image['name']}-${index}`} className="image-box">
+            <Icon
+              icon="ant-design:close-circle-filled"
+              className="image-delete-button"
+              onClick={() => {
+                setMoimImages(moimImages.filter((_, i) => i !== index));
+              }}
+            />
+            <img src={URL.createObjectURL(image)} alt={image['name']} />
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/client/src/hooks/WriteQuery.ts
+++ b/client/src/hooks/WriteQuery.ts
@@ -7,7 +7,7 @@ import { WalksMoimOneDay, WalksMoimEveryWeek } from '../models/WalksMoim';
 export function usePostMoimImage() {
   const handlePostMoimImage = async (files: File[]) => {
     if (files.length === 0) {
-      return null;
+      return [];
     }
 
     const formData = new FormData();
@@ -36,10 +36,6 @@ export function useAddOneDayMoim() {
     data: WalksMoimOneDay,
     moimImg: string[]
   ) => {
-    if (moimImg == null) {
-      moimImg = [];
-    }
-
     const res = await axios.post(
       `${API.WALKS}/post`,
       {
@@ -90,10 +86,6 @@ export function useAddEveryWeekMoim() {
     data: WalksMoimEveryWeek,
     moimImg: string[]
   ) => {
-    if (moimImg == null) {
-      moimImg = [];
-    }
-
     const res = await axios.post(
       `${API.WALKS}/post`,
       {
@@ -127,7 +119,6 @@ export function useAddEveryWeekMoim() {
         si: data.si,
         gu: data.gu,
         dong: data.dong,
-        // images: data.images,
         imgUrls: [...moimImg],
       },
       'moim'

--- a/client/src/pages/walks/[walkId]/[[...type]].tsx
+++ b/client/src/pages/walks/[walkId]/[[...type]].tsx
@@ -15,7 +15,7 @@ export default function Page({ walkId, type }: WalksPageProps) {
 
   return (
     <>
-      <TabTitle prefix={walkId} />
+      <TabTitle prefix={walkDetail?.name} />
       <DetailLayout walkId={walkId}>
         {type === 'notice' ? (
           <MoimNotice walkDetail={walkDetail} />

--- a/client/src/pages/walks/write.tsx
+++ b/client/src/pages/walks/write.tsx
@@ -7,6 +7,7 @@ import CommonButton from '../../components/CommonButton';
 import TabTitle from '../../components/TabTitle';
 import DescriptionInput from '../../components/walks/wirte/DescriptionInput';
 import EveryWeekPicker from '../../components/walks/wirte/EveryWeekPicker';
+import ImageUploadZone from '../../components/walks/wirte/ImageUploadZone';
 import OneDayPicker from '../../components/walks/wirte/OneDayPicker';
 import PersonCountInput from '../../components/walks/wirte/PersonCountInput';
 import PlaceInput from '../../components/walks/wirte/PlaceInput';
@@ -31,6 +32,8 @@ export default function Write() {
   const router = useRouter();
 
   const [user] = useRecoilState(UserState);
+  const [moimImages, setMoimImages] = useState<File[]>([]);
+
   const methods = useForm<WalksMoim>({
     mode: 'onChange',
     defaultValues: {
@@ -42,20 +45,6 @@ export default function Write() {
   const { handleAddOneDayMoim } = useAddOneDayMoim();
   const { handleAddEveryWeekMoim } = useAddEveryWeekMoim();
   const { handlePostMoimImage } = usePostMoimImage();
-
-  // 이미지 관련
-  const [moimImages, setMoimImages] = useState<File[]>([]);
-
-  const handleMoimImageChange = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    if (event.target.files) {
-      console.log(event);
-      const imageFile = event.target.files;
-      setMoimImages([...moimImages, ...Array.from(imageFile)]);
-    }
-  };
-  console.log(moimImages);
 
   const {
     register,
@@ -164,21 +153,20 @@ export default function Write() {
     <>
       <TabTitle prefix="모임 글쓰기" />
       <section css={moimFormContainer}>
-        <h1>🐕 산책 모임 만들기</h1>
+        <h1
+          css={css`
+            margin-bottom: 20px;
+          `}
+        >
+          🐕 산책 모임 만들기
+        </h1>
 
         <FormProvider {...methods}>
           <form>
-            <ul>
-              <li>
-                <input
-                  multiple
-                  type="file"
-                  accept="image/*"
-                  onChange={handleMoimImageChange}
-                />
-              </li>
-              <li>미리보기</li>
-            </ul>
+            <ImageUploadZone
+              moimImages={moimImages}
+              setMoimImages={setMoimImages}
+            />
             <ul>
               <li>
                 <label htmlFor="moim-name">모임의 이름을 지어주세요.</label>


### PR DESCRIPTION
<img width="803" alt="스크린샷 2022-10-04 오후 2 07 21" src="https://user-images.githubusercontent.com/76990149/193738884-dd8c1db0-6724-460c-b99e-abb33998dd01.png">

<img width="802" alt="스크린샷 2022-10-04 오후 2 06 10" src="https://user-images.githubusercontent.com/76990149/193738730-8c9c15f2-7eab-4d54-b1f0-a71037712176.png">

<img width="1080" alt="스크린샷 2022-10-04 오후 2 06 04" src="https://user-images.githubusercontent.com/76990149/193738741-9da93a18-0b83-46f6-82b6-7cf43cbfab6a.png">

- 이미지는 최대 3장만 선택할 수 있도록 했고, 선택한 이미지는 미리 볼 수 있고 삭제하고 다른 이미지를 추가하는 것도 가능합니다.
- 만약 이미지 없이 모임을 작성하면 기본 이미지가 들어갑니다.
