### PR TITLE
[FEAT] 모임 작성자의 강아지도 참여 강아지에 포함

### DIFF
--- a/client/src/components/DogChoiceModal.tsx
+++ b/client/src/components/DogChoiceModal.tsx
@@ -155,7 +155,7 @@ export default function DogChoiceModal({
 
   const handleGoTowalkClick = () => {
     if (goToWalksWrite) {
-      console.log(pickPetsId);
+      localStorage.setItem('pickPetsId', JSON.stringify(pickPetsId));
       router.push('/walks/write');
     } else if (!goToWalksWrite) {
       console.log(pickPetsId);
@@ -189,12 +189,7 @@ export default function DogChoiceModal({
           </p>
           <Link href={`/users/${user.id}`}>
             <a>
-              <CommonButton
-                type="button"
-                onClick={() => {
-                  setIsModalOpen(false);
-                }}
-              >
+              <CommonButton type="button" onClick={() => setIsModalOpen(false)}>
                 강아지 등록하러 가기
               </CommonButton>
             </a>

--- a/client/src/hooks/WriteQuery.ts
+++ b/client/src/hooks/WriteQuery.ts
@@ -49,6 +49,7 @@ export function useAddOneDayMoim() {
         gu: data.gu,
         dong: data.dong,
         imgUrls: [...moimImg],
+        joinnedPetList: [...data.joinnedPetList],
       },
       {
         headers: {
@@ -70,6 +71,7 @@ export function useAddOneDayMoim() {
         gu: data.gu,
         dong: data.dong,
         imgUrls: [...moimImg],
+        joinnedPetList: [...data.joinnedPetList],
       },
       'moim'
     );
@@ -99,6 +101,7 @@ export function useAddEveryWeekMoim() {
         gu: data.gu,
         dong: data.dong,
         imgUrls: [...moimImg],
+        joinnedPetList: [...data.joinnedPetList],
       },
       {
         headers: {
@@ -120,6 +123,7 @@ export function useAddEveryWeekMoim() {
         gu: data.gu,
         dong: data.dong,
         imgUrls: [...moimImg],
+        joinnedPetList: [...data.joinnedPetList],
       },
       'moim'
     );

--- a/client/src/models/WalksMoim.ts
+++ b/client/src/models/WalksMoim.ts
@@ -19,6 +19,7 @@ interface WalksMoimBase {
   si: string;
   gu: string;
   dong: string;
+  joinnedPetList: number[];
 }
 
 export const WalksMoimTypes = {
@@ -50,4 +51,5 @@ export interface EveryWeekMoimPost {
   si: string;
   gu: string;
   dong: string;
+  joinnedPetList: number[];
 }

--- a/client/src/pages/walks/index.tsx
+++ b/client/src/pages/walks/index.tsx
@@ -47,6 +47,11 @@ export default function Walks() {
       router.push('/login');
       return;
     }
+
+    if (!localStorage.getItem('currentAddress')) {
+      alert('동네를 선택해주세요');
+      return;
+    }
     console.log(user);
     setIsModalOpen(!isModalOpen);
   };

--- a/client/src/pages/walks/index.tsx
+++ b/client/src/pages/walks/index.tsx
@@ -52,6 +52,7 @@ export default function Walks() {
       alert('동네를 선택해주세요');
       return;
     }
+
     console.log(user);
     setIsModalOpen(!isModalOpen);
   };

--- a/client/src/pages/walks/write.tsx
+++ b/client/src/pages/walks/write.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
-import { useRecoilState } from 'recoil';
 import CommonButton from '../../components/CommonButton';
 import TabTitle from '../../components/TabTitle';
 import DescriptionInput from '../../components/walks/wirte/DescriptionInput';
@@ -24,14 +23,12 @@ import {
   WalksMoimType,
   WalksMoimTypes,
 } from '../../models/WalksMoim';
-import UserState from '../../states/UserState';
 import 'react-datepicker/dist/react-datepicker.css';
 import { Theme } from '../../styles/Theme';
 
 export default function Write() {
   const router = useRouter();
 
-  const [user] = useRecoilState(UserState);
   const [moimImages, setMoimImages] = useState<File[]>([]);
 
   const methods = useForm<WalksMoim>({
@@ -62,6 +59,8 @@ export default function Write() {
     (v: WalksMoimType) => setValue('type', v),
   ];
 
+  const [pickPetsId, setPickPetsId] = useState('');
+
   const onSubmitOneDay = (data: WalksMoimOneDay) => {
     const {
       type,
@@ -81,9 +80,10 @@ export default function Write() {
       personCount,
       plannedDate,
       plannedTime,
-      si: user.address.si,
-      gu: user.address.gu,
-      dong: user.address.dong,
+      si: localStorage.getItem('currentAddress')?.split(' ')[0] || '',
+      gu: localStorage.getItem('currentAddress')?.split(' ')[1] || '',
+      dong: localStorage.getItem('currentAddress')?.split(' ')[2] || '',
+      joinnedPetList: pickPetsId.slice(1, -1).split(',').map(Number),
     };
 
     return oneDayMoim;
@@ -108,9 +108,10 @@ export default function Write() {
       personCount,
       plannedDates,
       plannedTime,
-      si: user.address.si,
-      gu: user.address.gu,
-      dong: user.address.dong,
+      si: window.localStorage.getItem('currentAddress')?.split(' ')[0] || '',
+      gu: window.localStorage.getItem('currentAddress')?.split(' ')[1] || '',
+      dong: window.localStorage.getItem('currentAddress')?.split(' ')[2] || '',
+      joinnedPetList: pickPetsId.slice(1, -1).split(',').map(Number),
     };
 
     return everyWeekMoim;
@@ -142,6 +143,17 @@ export default function Write() {
       console.log(error);
     }
   };
+
+  useEffect(() => {
+    console.log(pickPetsId);
+    if (!window.localStorage.getItem('pickPetsId')) {
+      alert('반려견을 선택해주세요.');
+      router.push('/walks');
+      return;
+    }
+    setPickPetsId(localStorage.getItem('pickPetsId') || '');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pickPetsId]);
 
   useEffect(() => {
     resetField('plannedDate');

--- a/client/src/pages/walks/write.tsx
+++ b/client/src/pages/walks/write.tsx
@@ -145,7 +145,6 @@ export default function Write() {
   };
 
   useEffect(() => {
-    console.log(pickPetsId);
     if (!window.localStorage.getItem('pickPetsId')) {
       alert('반려견을 선택해주세요.');
       router.push('/walks');


### PR DESCRIPTION
- 모임 작성 시 산책할 강아지를 선택해야 모임을 작성할 수 있습니다.
  - 로컬 스토리지에 currentAddress 가 없다면 alert창으로 동네를 선택하라고 알려줍니다.
  - 로컬 스토리지에 선택한 강아지 id가 없다면 alert 창으로 반려견을 선택하라고 알려준 뒤 메인페이지로 이동합니다.

- 모임을 다 작성하고 나면 참여 강아지에 작성자의 강아지도 포함이 됩니다!

--- 

## 곧..?
- 모임 참여하기를 할 때 남은 인원에 따라 선택할 수 있는 강아지의 수를 제한하는 기능을 추가해보겠습니다.