### PR TITLE
[ADD] 새로운 순, 마감임박순 정렬시 마감된 모임 제외

### DIFF
--- a/server/src/main/java/com/main026/walking/community/controller/CommunityController.java
+++ b/server/src/main/java/com/main026/walking/community/controller/CommunityController.java
@@ -87,7 +87,7 @@ public class CommunityController {
     public ResponseEntity getCommunitiesWithNew(CommunitySearchCond communitySearchCond) {
         Sort sortNew = Sort.by("new").descending();
         PageRequest pageRequest = PageRequest.of(0,4,sortNew);
-
+        communitySearchCond.setCond("new");
         CommunityListResponseDto communities = communityService.findCommunities(communitySearchCond, pageRequest);
 
         return new ResponseEntity(communities, HttpStatus.OK);
@@ -97,7 +97,7 @@ public class CommunityController {
     public ResponseEntity getCommunitiesWithHot(CommunitySearchCond communitySearchCond) {
         Sort sortHot = Sort.by("hot");
         PageRequest pageRequest = PageRequest.of(0,4,sortHot);
-
+        communitySearchCond.setCond("hot");
         CommunityListResponseDto communities = communityService.findCommunities(communitySearchCond, pageRequest);
 
         return new ResponseEntity(communities, HttpStatus.OK);

--- a/server/src/main/java/com/main026/walking/community/dto/CommunitySearchCond.java
+++ b/server/src/main/java/com/main026/walking/community/dto/CommunitySearchCond.java
@@ -15,4 +15,5 @@ public class CommunitySearchCond {
     private String si;
     private String gu;
     private String dong;
+    private String cond;
 }

--- a/server/src/main/java/com/main026/walking/community/entity/Community.java
+++ b/server/src/main/java/com/main026/walking/community/entity/Community.java
@@ -99,10 +99,6 @@ public class Community {
         this.address = new Address(si, gu, dong);
     }
 
-    public void addPet(CommunityPet communityPet) {
-        this.communityPets.add(communityPet);
-    }
-
     @Builder
     public Community(Long id, String name, String body, Address address, String place, List<String> dates, String date, String time, Member representMember, Integer capacity, Long viewed, Long liked, LocalDateTime createdAt) {
         this.id = id;

--- a/server/src/main/java/com/main026/walking/community/repository/CommunityRepositoryImpl.java
+++ b/server/src/main/java/com/main026/walking/community/repository/CommunityRepositoryImpl.java
@@ -5,9 +5,7 @@ import com.main026.walking.community.entity.Community;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Visitor;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.NumberExpression;
-import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
@@ -52,7 +50,8 @@ public class CommunityRepositoryImpl implements CommunityRepositoryCustom{
                 .where(searchText(searchCond.getName()),
                         searchSi(searchCond.getSi()),
                         searchGu(searchCond.getGu()),
-                        searchDong(searchCond.getDong()))
+                        searchDong(searchCond.getDong()),
+                        isExpired(searchCond.getCond()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(boardSort(pageable))
@@ -83,6 +82,13 @@ public class CommunityRepositoryImpl implements CommunityRepositoryCustom{
     private BooleanExpression searchText(String name){
         if(StringUtils.hasText(name)){
             return community.name.like("%"+name+"%");
+        }
+        return null;
+    }
+
+    private BooleanExpression isExpired(String cond){
+        if(StringUtils.hasText(cond)){
+            return community.capacity.ne(community.communityPets.size());
         }
         return null;
     }


### PR DESCRIPTION
- /new /hot 정렬시 참여인원이 다 찬 모임은 검색되지않습니다.
- 날짜기준 마감은 조금 더 구현해보겠습니다