### PR TITLE
[FEAT] 로그인이 필요한 서비스에 로그인 권유 모달 보여주기 및 페이지 접근 관리

### DIFF
--- a/client/src/components/LoginOfferModal.tsx
+++ b/client/src/components/LoginOfferModal.tsx
@@ -1,0 +1,133 @@
+import { css, keyframes } from '@emotion/react';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { Theme } from '../styles/Theme';
+import CommonButton from './CommonButton';
+
+const modalContainer = (isModalOpen: boolean) => css`
+  &.modal-wrapper {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &.modal-wrapper section.modal {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 250px;
+    width: 100%;
+    max-width: 350px;
+    border-radius: 20px;
+    padding: 40px;
+    margin: 10px;
+    background-color: #fff;
+    z-index: 1;
+    word-break: keep-all;
+  }
+
+  section.modal {
+    display: ${isModalOpen ? 'block' : 'none'};
+    animation: ${isModalOpen ? fadeIn : fadeOut} 0.4s ease-out;
+  }
+
+  section.modal {
+    h1 {
+      color: ${Theme.mainColor};
+      font-size: 1.3rem;
+      margin-bottom: 20px;
+
+      @media screen and (max-width: 324px) {
+        font-size: 1.2rem;
+      }
+    }
+
+    h1 + div {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      word-break: keep-all;
+      gap: 10px;
+
+      @media screen and (max-width: 400px) {
+        grid-template-columns: 1fr;
+      }
+    }
+  }
+`;
+
+const fadeIn = keyframes`
+0% {
+  transform: translateY(100%);
+}
+
+100% {
+  transform: translateY(0px);
+}
+`;
+
+const fadeOut = keyframes`
+0% {
+  transform: translateY(0px);
+}
+
+100% {
+  transform: translateY(100%);
+}
+`;
+
+export default function LoginOfferModal({
+  isLoginOfferModalOpen,
+  setIsLoginOfferModalOpen,
+}: {
+  isLoginOfferModalOpen: boolean;
+  setIsLoginOfferModalOpen: (isLoginOfferModalOpen: boolean) => void;
+}) {
+  const router = useRouter();
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
+
+  return (
+    <div
+      className="modal-wrapper"
+      css={modalContainer(isLoginOfferModalOpen)}
+      onClick={() => setIsLoginOfferModalOpen(false)}
+    >
+      <section onClick={(e) => e.stopPropagation()} className="modal">
+        <h1>로그인이 필요해요!</h1>
+        <div>
+          <CommonButton
+            type="button"
+            padding="14px 0"
+            fontSize="0.9rem"
+            borderRadius="13px"
+            onClick={() => router.push('/login')}
+          >
+            로그인 하러 가기
+          </CommonButton>
+          <CommonButton
+            type="button"
+            padding="14px 0px"
+            fontSize="0.9rem"
+            onClick={() => setIsLoginOfferModalOpen(false)}
+            borderRadius="13px"
+            buttonColor={`${Theme.disableColor}`}
+          >
+            닫기
+          </CommonButton>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/client/src/components/login/LoginModal.tsx
+++ b/client/src/components/login/LoginModal.tsx
@@ -62,7 +62,11 @@ export default function LoginModal({
 
   useEffect(() => {
     if (isLoggedIn) {
-      router.push('/');
+      if (document.referrer && document.referrer.indexOf('/') !== -1) {
+        history.back(); // 뒤로가기
+      } else {
+        router.replace('/'); // 메인페이지로
+      }
     }
   }, [isLoggedIn, router]);
 
@@ -147,7 +151,6 @@ export default function LoginModal({
 
 const modalContainer = (isLoginModalOpen: boolean) => css`
   &.modal-wrapper {
-    justify-content: center;
     position: fixed;
     top: 0;
     left: 0;
@@ -157,6 +160,7 @@ const modalContainer = (isLoginModalOpen: boolean) => css`
     z-index: 1;
     display: flex;
     align-items: center;
+    justify-content: center;
   }
 
   &.modal-wrapper section.modal {

--- a/client/src/components/users/LogoutButton.tsx
+++ b/client/src/components/users/LogoutButton.tsx
@@ -14,6 +14,7 @@ export default function LogoutButton() {
     localStorage.removeItem('refreshToken');
     localStorage.removeItem('userId');
     localStorage.removeItem('currentAddress');
+    localStorage.removeItem('pickPetsId');
     setIsLogin(false);
     setUserState(null);
     router.push('/');

--- a/client/src/components/walks/walksDetail/DetailLayout.tsx
+++ b/client/src/components/walks/walksDetail/DetailLayout.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable @next/next/no-img-element */
 import { css } from '@emotion/react';
-import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { useWalksDetailQuery } from '../../../hooks/WalksQuery';
 import UserState from '../../../states/UserState';
 import CommonButton from '../../CommonButton';
 import DogChoiceModal from '../../DogChoiceModal';
+import LoginOfferModal from '../../LoginOfferModal';
 import Carousel from '../Carousel';
 import DogInfoModal from './DogInfoModal';
 import Information from './Information';
@@ -23,12 +23,11 @@ export default function DetailLayout({
   walkId: string;
   children: React.ReactNode;
 }) {
-  const router = useRouter();
-
   const walkDetail = useWalksDetailQuery(walkId);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDogInfoModalOpen, setIsDogInfoModalOpen] = useState(false);
+  const [isLoginOfferModalOpen, setIsLoginOfferModalOpen] = useState(false);
   const [petInfoId, setPetInfoId] = useState(1);
   const [moimState, setMoimState] = useState(true);
   const [user] = useRecoilState(UserState);
@@ -39,7 +38,7 @@ export default function DetailLayout({
 
   const handleMoimJoimButtonClick = () => {
     if (user == null) {
-      router.push('/login');
+      setIsLoginOfferModalOpen(true);
       return;
     }
     return setIsModalOpen(true);
@@ -110,7 +109,10 @@ export default function DetailLayout({
             setIsDogInfoModalOpen={setIsDogInfoModalOpen}
             getPetId={getPetId}
           />
-          <Comments walkDetail={walkDetail} />
+          <Comments
+            walkDetail={walkDetail}
+            setIsLoginOfferModalOpen={setIsLoginOfferModalOpen}
+          />
         </div>
         <div className="sticky-info-container">
           <StickyInfo
@@ -120,6 +122,7 @@ export default function DetailLayout({
           />
         </div>
       </section>
+
       {isModalOpen && (
         <DogChoiceModal
           isModalOpen={isModalOpen}
@@ -134,6 +137,12 @@ export default function DetailLayout({
           petId={petInfoId}
         />
       )}
+      {isLoginOfferModalOpen && (
+        <LoginOfferModal
+          isLoginOfferModalOpen={isLoginOfferModalOpen}
+          setIsLoginOfferModalOpen={setIsLoginOfferModalOpen}
+        />
+      )}
     </>
   );
 }
@@ -143,6 +152,7 @@ const sancheckDetailLayout = css`
   grid-template-columns: 1fr 310px;
   gap: 0 20px;
   margin: 110px 36px 10px;
+  padding-bottom: 30px;
 
   ul {
     list-style: none;
@@ -150,7 +160,6 @@ const sancheckDetailLayout = css`
 
   @media screen and (max-width: 880px) {
     margin: 30px 20px;
-    padding-bottom: 30px;
     grid-template-columns: 1fr;
 
     .sticky-info-container {

--- a/client/src/components/walks/walksDetail/comment/CommentInput.tsx
+++ b/client/src/components/walks/walksDetail/comment/CommentInput.tsx
@@ -1,8 +1,10 @@
 import { css } from '@emotion/react';
 import { useRouter } from 'next/router';
 import { useState, KeyboardEvent } from 'react';
+import { useRecoilState } from 'recoil';
 import { usePostComment } from '../../../../hooks/CommentQuery';
 import { WalkDetail } from '../../../../models/WalkDefault';
+import UserState from '../../../../states/UserState';
 import { Theme } from '../../../../styles/Theme';
 
 const inputContainer = css`
@@ -17,6 +19,10 @@ const inputContainer = css`
     padding-left: 18px;
     box-shadow: 0 1px 2px hsl(0deg 0% 0% / 5%), 0 1px 4px hsl(0deg 0% 0% / 5%),
       0 2px 8px hsl(0deg 0% 0% / 5%);
+
+    @media screen and (max-width: 300px) {
+      padding-left: 10px;
+    }
   }
 
   button {
@@ -38,10 +44,13 @@ const inputContainer = css`
 
 export default function CommentInput({
   walkDetail,
+  setIsLoginOfferModalOpen,
 }: {
   walkDetail: WalkDetail;
+  setIsLoginOfferModalOpen: (isLoginOfferModalOpen: boolean) => void;
 }) {
   const [body, setBody] = useState('');
+  const [user] = useRecoilState(UserState);
   const id = walkDetail.communityId;
   const { handlePostComment } = usePostComment();
   const router = useRouter();
@@ -64,6 +73,21 @@ export default function CommentInput({
       router.reload();
     }
   };
+
+  if (user == null) {
+    return (
+      <article css={inputContainer}>
+        <input
+          type="text"
+          placeholder="로그인 후 댓글을 작성할 수 있어요"
+          onClick={() => setIsLoginOfferModalOpen(true)}
+        />
+        <button type="button" onClick={handleRegisterClick}>
+          등록
+        </button>
+      </article>
+    );
+  }
 
   return (
     <article css={inputContainer}>

--- a/client/src/components/walks/walksDetail/comment/Comments.tsx
+++ b/client/src/components/walks/walksDetail/comment/Comments.tsx
@@ -96,7 +96,13 @@ const commentContainer = css`
   }
 `;
 
-export default function Comments({ walkDetail }: { walkDetail?: WalkDetail }) {
+export default function Comments({
+  walkDetail,
+  setIsLoginOfferModalOpen,
+}: {
+  walkDetail?: WalkDetail;
+  setIsLoginOfferModalOpen: (value: boolean) => void;
+}) {
   const router = useRouter();
 
   const { handlDeleteComment } = useDeleteComment();
@@ -148,7 +154,10 @@ export default function Comments({ walkDetail }: { walkDetail?: WalkDetail }) {
             <p className="comment-owner">댓글을 남겨주세요.</p>
           </li>
         </ul>
-        <CommentInput walkDetail={walkDetail} />
+        <CommentInput
+          walkDetail={walkDetail}
+          setIsLoginOfferModalOpen={setIsLoginOfferModalOpen}
+        />
       </article>
     );
   }
@@ -215,7 +224,10 @@ export default function Comments({ walkDetail }: { walkDetail?: WalkDetail }) {
           ))}
         </ul>
       </article>
-      <CommentInput walkDetail={walkDetail} />
+      <CommentInput
+        walkDetail={walkDetail}
+        setIsLoginOfferModalOpen={setIsLoginOfferModalOpen}
+      />
     </>
   );
 }

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,11 +1,14 @@
 import { css } from '@emotion/react';
 import { Icon } from '@iconify/react';
 import Link from 'next/link';
-import { MouseEvent, useState } from 'react';
+import { useRouter } from 'next/router';
+import { MouseEvent, useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
 import TabTitle from '../components/TabTitle';
 import LoginButton from '../components/login/LoginButton';
 import LoginModal from '../components/login/LoginModal';
 import PasswordModal from '../components/login/PasswordModal';
+import UserState from '../states/UserState';
 
 const signupButtonContainer = css`
   display: grid;
@@ -50,6 +53,12 @@ const loginButton = (gridColumn: string) => css`
 `;
 
 export default function Login() {
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+  const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
+  const [user] = useRecoilState(UserState);
+
+  const router = useRouter();
+
   const handleGoogleLoginClick = (event: MouseEvent) => {
     event.preventDefault();
     console.log('Google login button clicked');
@@ -65,8 +74,12 @@ export default function Login() {
     setIsPasswordModalOpen(!isPasswordModalOpen);
   };
 
-  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
-  const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
+  useEffect(() => {
+    if (user) {
+      router.replace('/');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <>

--- a/client/src/pages/signup.tsx
+++ b/client/src/pages/signup.tsx
@@ -85,7 +85,7 @@ export default function Signup() {
     formState: { errors, isValid },
   } = methods;
 
-  const [, setUser] = useRecoilState(UserState);
+  const [user, setUser] = useRecoilState(UserState);
   const [, setIsLoggedIn] = useRecoilState(LoginState);
 
   const { handleSignup } = useSignup();
@@ -124,6 +124,13 @@ export default function Signup() {
   useEffect(() => {
     setFocus('email');
   }, [setFocus]);
+
+  useEffect(() => {
+    if (user) {
+      router.replace('/');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <>

--- a/client/src/pages/walks/index.tsx
+++ b/client/src/pages/walks/index.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
-import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import DogChoiceModal from '../../components/DogChoiceModal';
+import LoginOfferModal from '../../components/LoginOfferModal';
 import SearchInput from '../../components/SearchInput';
 import TabTitle from '../../components/TabTitle';
 import AddButton from '../../components/walks/AddButton';
@@ -40,11 +40,11 @@ export default function Walks() {
   const [user] = useRecoilState(UserState);
   const [query, setQuery] = useState('');
   const [address, setAddress] = useState('');
-  const router = useRouter();
+  const [isLoginOfferModalOpen, setIsLoginOfferModalOpen] = useState(false);
 
   const handleModalClick = () => {
     if (user == null) {
-      router.push('/login');
+      setIsLoginOfferModalOpen(true);
       return;
     }
 
@@ -99,6 +99,13 @@ export default function Walks() {
           <AddButton onClick={handleModalClick} />
         </div>
       </section>
+
+      {isLoginOfferModalOpen && (
+        <LoginOfferModal
+          isLoginOfferModalOpen={isLoginOfferModalOpen}
+          setIsLoginOfferModalOpen={setIsLoginOfferModalOpen}
+        />
+      )}
     </>
   );
 }

--- a/client/src/pages/walks/write.tsx
+++ b/client/src/pages/walks/write.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
+import { useRecoilState } from 'recoil';
 import CommonButton from '../../components/CommonButton';
 import TabTitle from '../../components/TabTitle';
 import DescriptionInput from '../../components/walks/wirte/DescriptionInput';
@@ -24,12 +25,14 @@ import {
   WalksMoimTypes,
 } from '../../models/WalksMoim';
 import 'react-datepicker/dist/react-datepicker.css';
+import UserState from '../../states/UserState';
 import { Theme } from '../../styles/Theme';
 
 export default function Write() {
   const router = useRouter();
 
   const [moimImages, setMoimImages] = useState<File[]>([]);
+  const [user] = useRecoilState(UserState);
 
   const methods = useForm<WalksMoim>({
     mode: 'onChange',
@@ -128,6 +131,7 @@ export default function Write() {
         );
         const communityId = await moimResponse.data.communityId;
         await router.push(`/walks/${communityId}`);
+        localStorage.removeItem('pickPetsId');
       } else {
         const moimImageResponse = await handlePostMoimImage(moimImages);
         const oneDayMoimData = onSubmitOneDay(data);
@@ -137,6 +141,7 @@ export default function Write() {
         );
         const communityId = await moimResponse.data.communityId;
         await router.push(`/walks/${communityId}`);
+        localStorage.removeItem('pickPetsId');
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
@@ -145,8 +150,13 @@ export default function Write() {
   };
 
   useEffect(() => {
+    if (user == null) {
+      router.replace('/');
+      return;
+    }
+
     if (!window.localStorage.getItem('pickPetsId')) {
-      alert('반려견을 선택해주세요.');
+      alert('잘못된 접근입니다!');
       router.push('/walks');
       return;
     }


### PR DESCRIPTION
- 댓글, 모임 참여하기, 모임 작성하기 와 같이 로그인이 필요한 서비스를 이용하려고 할 때 `/login` 페이지로 바로 이동하는 게 아닌 로그인 권유 모달을 보여준 뒤 로그인 하러 가기 를 누르면 로그인 페이지로 이동하게끔 했습니다.

<img width="373" alt="스크린샷 2022-10-05 오전 11 28 39" src="https://user-images.githubusercontent.com/76990149/193977222-1f6ea277-53ca-4985-8765-3d03d4e110d9.png">

<img width="578" alt="스크린샷 2022-10-05 오전 11 28 34" src="https://user-images.githubusercontent.com/76990149/193977273-7d8d0bd7-d075-470b-b53d-5c8595b09434.png">

- **로그인이 필요해요! 이런,, 문구에 대해 고민이 있는데,,, 좀 더 좋은 문구가 있다면 알려주세용**

- 로그인을 하지 않은 상태에서 `/walks/write` 페이지에 접근하면 바로 `/` 페이지로 이동시킵니다.
- 로그인한 상태에서 `/login`, `/singup` 페이지에 접근하면 바로 `/` 페이지로 이동시킵니다.
- **확인한다고 열심히 확인하긴 했는데 페이지를 이동시키는 과정에서 오류가 있을 수도 있고 빠트린 부분도 있을 거에용,, 만약 발견하신다면 바로 알려주세요!!** 
    - redirect 를 조금 더 알아보고 수정할 수 있으면 수정하겠습니다! 
