### PR TITLE
[CHORE] css 수정 및 탭 이동시 쌓이던 history 문제 해결

### DIFF
--- a/client/src/components/MainImage.tsx
+++ b/client/src/components/MainImage.tsx
@@ -4,6 +4,15 @@ import NoticeModal from './NoticeModal';
 
 export default function MainImage() {
   const img = css`
+    position: absolute;
+
+    @media screen and (max-width: 768px) {
+      top: 0px;
+    }
+
+    top: 75px;
+    left: 0;
+    right: 0;
     width: 100%;
     background-size: cover;
     background-position-y: 30%;

--- a/client/src/components/NavLink.tsx
+++ b/client/src/components/NavLink.tsx
@@ -6,11 +6,13 @@ export default function NavLink({
   children,
   className,
   scroll,
+  replace,
 }: {
   href: string;
   children: React.ReactNode;
   className?: string;
   scroll?: boolean;
+  replace?: boolean;
 }) {
   const { asPath } = useRouter();
 
@@ -25,7 +27,7 @@ export default function NavLink({
   }
 
   return (
-    <Link href={href} scroll={scroll}>
+    <Link href={href} scroll={scroll} replace={replace}>
       <a className={className}>{children}</a>
     </Link>
   );

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { css } from '@emotion/react';
 import { Icon } from '@iconify/react';
-import Link from 'next/link';
 import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import { LoginState } from '../states/LoginState';
 import UserState from '../states/UserState';
+import NavLink from './NavLink';
 
 export default function Navbar() {
   const [isLoggedIn, setIsLoggedIn] = useRecoilState(LoginState);
@@ -16,13 +16,19 @@ export default function Navbar() {
       position: fixed;
       bottom: 0;
       width: 100%;
-      padding: 1rem 3rem;
-      background-color: #fff3e3;
-      display: flex;
-      justify-content: space-around;
-      align-items: center;
       height: 72px;
+      background-color: #fff3e3;
       z-index: 2;
+
+      ul {
+        display: flex;
+        align-items: center;
+        justify-content: space-around;
+        list-style: none;
+        width: 100%;
+        height: 100%;
+      }
+
       a {
         opacity: 50%;
         color: #dc602a;
@@ -41,6 +47,9 @@ export default function Navbar() {
           opacity: 100%;
         }
         :active {
+          opacity: 100%;
+        }
+        &.active {
           opacity: 100%;
         }
       }
@@ -65,11 +74,16 @@ export default function Navbar() {
       list-style: none;
     }
     a {
+      opacity: 0.8;
       text-decoration: none;
       color: black;
       font-size: 1rem;
       :hover {
         font-weight: 500;
+      }
+      &.active {
+        font-weight: 500;
+        color: #dc602a;
       }
     }
     .logo {
@@ -101,63 +115,61 @@ export default function Navbar() {
   return (
     <>
       <nav css={mobile_navbar}>
-        <Link href="/">
-          <a>
-            <Icon icon="akar-icons:home" className="icon" />
-            <p className="nav_text">메인</p>
-          </a>
-        </Link>
-        <Link href="/walks">
-          <a>
-            <Icon icon="ph:dog" className="icon" />
-            <p className="nav_text">산책 찾기</p>
-          </a>
-        </Link>
-        {isLoggedIn ? (
-          <Link href={`/users/${user.id}`}>
-            <a>
-              <Icon
-                icon="fluent-emoji-high-contrast:paw-prints"
-                className="icon"
-              />
-              <p className="nav_text">마이페이지</p>
-            </a>
-          </Link>
-        ) : (
-          <Link href="/login">
-            <a>
-              <Icon
-                icon="fluent-emoji-high-contrast:paw-prints"
-                className="icon"
-              />
-              <p className="nav_text">마이페이지</p>
-            </a>
-          </Link>
-        )}
+        <ul>
+          <li>
+            <NavLink href="/">
+              <Icon icon="akar-icons:home" className="icon" />
+              <p className="nav_text">메인</p>
+            </NavLink>
+          </li>
+          <li>
+            <NavLink href="/walks">
+              <Icon icon="ph:dog" className="icon" />
+              <p className="nav_text">산책 찾기</p>
+            </NavLink>
+          </li>
+          {isLoggedIn ? (
+            <li>
+              <NavLink href={`/users/${user.id}`}>
+                <Icon
+                  icon="fluent-emoji-high-contrast:paw-prints"
+                  className="icon"
+                />
+                <p className="nav_text">마이페이지</p>
+              </NavLink>
+            </li>
+          ) : (
+            <li>
+              <NavLink href="/login">
+                <Icon
+                  icon="fluent-emoji-high-contrast:paw-prints"
+                  className="icon"
+                />
+                <p className="nav_text">마이페이지</p>
+              </NavLink>
+            </li>
+          )}
+        </ul>
       </nav>
       <nav css={desktop_navbar}>
         <div className="menus">
           <ul className="tabs">
             <li className="logo">ㅅㅊ</li>
             <li>
-              <Link href="/">
-                <a>홈</a>
-              </Link>
+              <NavLink href="/">홈</NavLink>
             </li>
             <li>
-              <Link href="/walks">
-                <a>산책 찾기</a>
-              </Link>
+              <NavLink href="/walks">산책 찾기</NavLink>
             </li>
           </ul>
           {isLoggedIn ? (
-            <Link href={`/users/${user.id}`}>
-              <a>마이페이지</a>
-            </Link>
+            <li>
+              <NavLink href={`/users/${user.id}`}>마이페이지</NavLink>
+            </li>
           ) : (
-            <Link href="/login">
-              <a>로그인/회원가입</a>
-            </Link>
+            <li>
+              <NavLink href="/login">로그인/회원가입</NavLink>
+            </li>
           )}
         </div>
       </nav>

--- a/client/src/components/walks/WalkItem.tsx
+++ b/client/src/components/walks/WalkItem.tsx
@@ -17,6 +17,11 @@ export default function WalkItem({ walk }: { walk: WalkDefault }) {
     margin: 1rem 0.5rem;
     border-radius: 15px;
     overflow: hidden;
+
+    @media screen and (max-width: 330px) {
+      max-width: 250px;
+    }
+
     .img {
       object-fit: cover;
     }

--- a/client/src/components/walks/WalksList.tsx
+++ b/client/src/components/walks/WalksList.tsx
@@ -7,32 +7,30 @@ import { Theme } from '../../styles/Theme';
 import WalkItem from './WalkItem';
 import LoadingWalkItem from './skeleton/LoadingWalkItem';
 
+const walksList = css`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 350px));
+  justify-items: center;
+  justify-content: center;
+  grid-gap: 1rem;
+  margin-top: 2rem;
+
+  p.alert {
+    margin: 2rem;
+    color: ${Theme.disableColor};
+  }
+
+  @media screen and (max-width: 350px) {
+    grid-template-columns: minmax(250px, 1fr);
+  }
+`;
+
 export default function WalksList({ query }: { query: string }) {
   const getWalksQuery = useGetWalksQuery(query);
 
   useEffect(() => {
     getWalksQuery.refetch();
   }, [query]);
-
-  const walksList = css`
-    display: grid;
-    grid-template-columns: 30% 30% 30%;
-    place-content: center;
-    p.alert {
-      margin: 2rem;
-      color: ${Theme.disableColor};
-    }
-    @media screen and (max-width: 1200px) {
-      display: grid;
-      grid-template-columns: 45% 45%;
-      place-content: center;
-    }
-    @media screen and (max-width: 768px) {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
-  `;
 
   return (
     <section css={walksList}>

--- a/client/src/components/walks/walksDetail/Introduce.tsx
+++ b/client/src/components/walks/walksDetail/Introduce.tsx
@@ -12,6 +12,7 @@ export default function Introduce({ walkDetail }: { walkDetail?: WalkDetail }) {
       <article css={contentContainer}>
         <p
           css={css`
+            line-height: 1.5;
             border-radius: 10px;
             -webkit-animation: ${skeletonGradient} 1.8s infinite ease-in-out;
             animation: ${skeletonGradient} 1.8s infinite ease-in-out;

--- a/client/src/components/walks/walksDetail/PageNav.tsx
+++ b/client/src/components/walks/walksDetail/PageNav.tsx
@@ -47,12 +47,12 @@ export default function PageNav() {
   return (
     <ul css={pageNavContainer}>
       <li>
-        <NavLink href={`/walks/${walkId}`} scroll={false}>
+        <NavLink href={`/walks/${walkId}`} scroll={false} replace={true}>
           모임 소개
         </NavLink>
       </li>
       <li>
-        <NavLink href={`/walks/${walkId}/notice`} scroll={false}>
+        <NavLink href={`/walks/${walkId}/notice`} scroll={false} replace={true}>
           모임 공지사항
         </NavLink>
       </li>

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -9,6 +9,12 @@ import { Theme } from '../styles/Theme';
 
 const index = css`
   margin-bottom: 4rem;
+  margin-top: calc(30vh + 75px + 1rem);
+
+  @media screen and (max-width: 768px) {
+    margin-top: calc(30vh + 1rem);
+  }
+
   .new_walks,
   .hot_walks {
     margin: 1rem;
@@ -32,35 +38,37 @@ const Home: NextPage = () => {
   }, []);
 
   return (
-    <section css={index}>
+    <>
       <TabTitle prefix="지금 핫한 모임" />
-      <MainImage />
-      <AddressPicker setAddress={setAddress} />
-      <div className="new_walks">
-        <h2 className="walks_title">✨ 동네 신규 산책</h2>
-        {address ? (
-          <WalksList
-            query={`/new?si=${address?.split(' ')[0]}&gu=${
-              address?.split(' ')[1]
-            }&dong=${address?.split(' ')[2]}`}
-          />
-        ) : (
-          <p className="alert">동네를 선택하세요</p>
-        )}
-      </div>
-      <div className="hot_walks">
-        <h2 className="walks_title">🔥 마감 임박 산책 </h2>
-        {address ? (
-          <WalksList
-            query={`/hot?si=${address?.split(' ')[0]}&gu=${
-              address?.split(' ')[1]
-            }&dong=${address?.split(' ')[2]}`}
-          />
-        ) : (
-          <p className="alert">동네를 선택하세요</p>
-        )}
-      </div>
-    </section>
+      <section css={index}>
+        <MainImage />
+        <AddressPicker setAddress={setAddress} />
+        <div className="new_walks">
+          <h2 className="walks_title">✨ 동네 신규 산책</h2>
+          {address ? (
+            <WalksList
+              query={`/new?si=${address?.split(' ')[0]}&gu=${
+                address?.split(' ')[1]
+              }&dong=${address?.split(' ')[2]}`}
+            />
+          ) : (
+            <p className="alert">동네를 선택하세요</p>
+          )}
+        </div>
+        <div className="hot_walks">
+          <h2 className="walks_title">🔥 마감 임박 산책 </h2>
+          {address ? (
+            <WalksList
+              query={`/hot?si=${address?.split(' ')[0]}&gu=${
+                address?.split(' ')[1]
+              }&dong=${address?.split(' ')[2]}`}
+            />
+          ) : (
+            <p className="alert">동네를 선택하세요</p>
+          )}
+        </div>
+      </section>
+    </>
   );
 };
 

--- a/client/src/pages/users/[userId].tsx
+++ b/client/src/pages/users/[userId].tsx
@@ -15,36 +15,36 @@ import { useGetUsersQuery } from '../../hooks/UsersQuery';
 import UserState from '../../states/UserState';
 import { Theme } from '../../styles/Theme';
 
+const userPage = css`
+  margin: 15vw 20vw;
+  display: flex;
+  flex-direction: column;
+  .walks {
+    display: flex;
+    align-items: center;
+    padding: 1rem 0;
+    border-bottom: 1px solid ${Theme.divisionLineColor};
+    font-weight: 500;
+    .icon {
+      margin-right: 0.5rem;
+      font-size: 1.7rem;
+    }
+    span {
+      font-weight: 600;
+      color: ${Theme.mainColor};
+      margin: 0 0.2rem 0rem 0rem;
+    }
+  }
+
+  @media screen and (max-width: 450px) {
+    margin: 15vw 10vw;
+  }
+`;
+
 export default function User({ userId }: { userId: string }) {
   const [isValidated, setIsValidated] = useState(false);
   const [user] = useRecoilState(UserState);
   const getUsersQuery = useGetUsersQuery(userId);
-
-  const userPage = css`
-    margin: 15vw 20vw;
-    display: flex;
-    flex-direction: column;
-    .walks {
-      display: flex;
-      align-items: center;
-      padding: 1rem 0;
-      border-bottom: 1px solid ${Theme.divisionLineColor};
-      font-weight: 500;
-      .icon {
-        margin-right: 0.5rem;
-        font-size: 1.7rem;
-      }
-      span {
-        font-weight: 600;
-        color: ${Theme.mainColor};
-        margin: 0 0.2rem 0rem 0rem;
-      }
-    }
-
-    @media screen and (max-width: 450px) {
-      margin: 15vw 10vw;
-    }
-  `;
 
   useEffect(() => {
     if (user) {

--- a/client/src/pages/users/[userId].tsx
+++ b/client/src/pages/users/[userId].tsx
@@ -40,6 +40,10 @@ export default function User({ userId }: { userId: string }) {
         margin: 0 0.2rem 0rem 0rem;
       }
     }
+
+    @media screen and (max-width: 450px) {
+      margin: 15vw 10vw;
+    }
   `;
 
   useEffect(() => {

--- a/client/src/pages/walks/index.tsx
+++ b/client/src/pages/walks/index.tsx
@@ -22,6 +22,8 @@ const header = css`
 `;
 
 const walksWrapper = css`
+  margin: 0 1rem;
+
   h2 {
     font-weight: 500;
     font-size: 22px;


### PR DESCRIPTION
## 변경사항

<img width="709" alt="스크린샷 2022-10-09 오후 6 29 10" src="https://user-images.githubusercontent.com/76990149/194749122-d6b8000f-3a38-4dcc-ab1d-0a640269435a.png">

- 현재 탭이 어디인지 알아차릴 수 있도록 스타일 수정했습니다! (모바일 메뉴바와 데스크톱 메뉴바 둘 다 적용)

<img width="1484" alt="스크린샷 2022-10-09 오후 6 30 42" src="https://user-images.githubusercontent.com/76990149/194749168-a1565ef0-0385-41ee-bddf-8e0bfc804019.png">

<img width="1732" alt="스크린샷 2022-10-09 오후 6 29 00" src="https://user-images.githubusercontent.com/76990149/194749124-7df5af37-ddbf-4150-8ffd-71cb3c4d42e5.png">

- 메인 이미지 부분이 화면에 꽉 차도록 한 번 해봤습니다! 별로면 말씀해주세요! 되돌려놓을게용
- 그리고 조금씩 자잘한 부분들 수정했습니다! 

- 모임 소개, 모임 공지사항 탭 이동할 때마다  history가 쌓여서 뒤로가기가 제대로 동작하지 않은 문제 해결했습니다!