### PR TITLE
[CHORE] safari css 수정

### DIFF
--- a/client/public/arrow-down.svg
+++ b/client/public/arrow-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" preserveAspectRatio="xMidYMid meet" viewBox="0 0 1024 1024"><path fill="currentColor" d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"/></svg>

--- a/client/src/components/DogChoiceModal.tsx
+++ b/client/src/components/DogChoiceModal.tsx
@@ -26,7 +26,7 @@ const modalContainer = (isModalOpen: boolean) => css`
   }
 
   &.modal-wrapper section.modal {
-    position: absolute;
+    position: fixed;
     bottom: 0;
     width: 100%;
     max-width: 1200px;

--- a/client/src/components/DogChoiceModal.tsx
+++ b/client/src/components/DogChoiceModal.tsx
@@ -26,6 +26,8 @@ const modalContainer = (isModalOpen: boolean) => css`
   }
 
   &.modal-wrapper section.modal {
+    position: absolute;
+    bottom: 0;
     width: 100%;
     max-width: 1200px;
     border-radius: 20px 20px 0 0;

--- a/client/src/components/login/LoginModal.tsx
+++ b/client/src/components/login/LoginModal.tsx
@@ -27,7 +27,6 @@ export default function LoginModal({
   const {
     register,
     handleSubmit,
-    setFocus,
     formState: { errors, isValid },
     reset,
   } = methods;
@@ -76,10 +75,6 @@ export default function LoginModal({
       document.body.style.overflow = 'unset';
     };
   }, []);
-
-  useEffect(() => {
-    setFocus('email');
-  }, [setFocus]);
 
   return (
     <div
@@ -211,6 +206,10 @@ const modalContainer = (isLoginModalOpen: boolean) => css`
     font-weight: 600;
     color: ${Theme.mainColor};
     gap: 0px 10px;
+
+    dt {
+      word-break: keep-all;
+    }
 
     input {
       width: 100%;

--- a/client/src/components/walks/AddressModal.tsx
+++ b/client/src/components/walks/AddressModal.tsx
@@ -192,11 +192,6 @@ export default function AddressModal({
       background-position: right 0.5rem top 50%;
       background-size: 1rem;
 
-      text-align-last: center;
-      text-align: center;
-      -ms-text-align-last: center;
-      -moz-text-align-last: center;
-
       :focus {
         outline: none;
       }

--- a/client/src/components/walks/AddressModal.tsx
+++ b/client/src/components/walks/AddressModal.tsx
@@ -87,13 +87,14 @@ export default function AddressModal({
     }
 
     &.modal-wrapper section.modal {
+      position: fixed;
+      bottom: 0;
       width: 100%;
       max-width: 1200px;
       border-radius: 20px 20px 0 0;
       padding: 42px 41px 22px;
       background-color: #fff;
       z-index: 1;
-      position: fixed;
 
       h1 {
         font-size: 1.3rem;
@@ -170,16 +171,33 @@ export default function AddressModal({
     display: flex;
     flex-direction: column;
     justify-content: center;
+    position: relative;
+
     select {
       background-color: ${Theme.inputBgColor};
       text-align: center;
       font-size: 11px;
       border-radius: 0.5rem;
       border: 0;
-      padding: 1rem;
+      padding: 1rem 1.5rem 1rem 1rem;
       margin-bottom: 1rem;
       font-weight: 500;
       height: 3rem;
+      cursor: pointer;
+
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      appearance: none;
+      background-image: url('/arrow-down.svg');
+      background-repeat: no-repeat;
+      background-position: right 0.5rem top 50%;
+      background-size: 1rem;
+
+      text-align-last: center;
+      text-align: center;
+      -ms-text-align-last: center;
+      -moz-text-align-last: center;
+
       :focus {
         outline: none;
       }

--- a/client/src/components/walks/AddressModal.tsx
+++ b/client/src/components/walks/AddressModal.tsx
@@ -171,7 +171,6 @@ export default function AddressModal({
     display: flex;
     flex-direction: column;
     justify-content: center;
-    position: relative;
 
     select {
       background-color: ${Theme.inputBgColor};

--- a/client/src/pages/signup.tsx
+++ b/client/src/pages/signup.tsx
@@ -53,6 +53,17 @@ const signUpContainer = css`
     }
   }
 
+  select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-image: url('/arrow-down.svg');
+    background-repeat: no-repeat;
+    background-position: right 0.5rem top 50%;
+    background-size: 1rem;
+    cursor: pointer;
+  }
+
   h2 {
     font-size: 1.1rem;
   }

--- a/client/src/pages/walks/index.tsx
+++ b/client/src/pages/walks/index.tsx
@@ -23,7 +23,7 @@ const header = css`
 
 const walksWrapper = css`
   margin: 0 1rem;
-  padding-bottom: 90px;
+  padding-bottom: 100px;
 
   h2 {
     font-weight: 500;


### PR DESCRIPTION
<img width="1067" alt="스크린샷 2022-10-11 오후 2 46 49" src="https://user-images.githubusercontent.com/76990149/195023648-c73e1852-5437-4492-b765-9bd3d88875dc.png">

safari에서는 select 창이 이상하게 보였습니다... 또 모달창이 이상한 위치에 뜨길래 select 창 css 수정하고 모달창 위치도 조정했습니다!

select창 css 수정하면서 화살표 버튼이 없어져서 화살표 버튼도 넣었습니다!

<img width="1067" alt="스크린샷 2022-10-11 오후 2 47 02" src="https://user-images.githubusercontent.com/76990149/195023925-0e6e5a23-5c93-4f24-b5ad-2eb0a1011210.png">

<img width="319" alt="스크린샷 2022-10-11 오후 3 05 29" src="https://user-images.githubusercontent.com/76990149/195023900-dc83e619-b350-4b85-b441-fbda4db4b652.png">
